### PR TITLE
🔧 fix: uses "/home/agent/workspace" as default workspace for agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The `[agent]` key in a `jcard.toml`
 [agent]
 harness = "claude-code"
 prompt = "review the code and fix failing tests"
-workdir = "/workspace"
+workdir = "/home/agent/workspace"
 restart = "on-failure"
 max_restarts = 5
 timeout = "2h"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,7 +27,7 @@ const (
 
 const (
 	// DefaultWorkdir is the default working directory for agents.
-	DefaultWorkdir = "/workspace"
+	DefaultWorkdir = "/home/agent/workspace"
 
 	// DefaultGracePeriod is the default SIGTERM-to-SIGKILL grace period.
 	DefaultGracePeriod = "30s"
@@ -59,7 +59,7 @@ type AgentConfig struct {
 	PromptFile string `toml:"prompt_file,omitempty"`
 
 	// Workdir is the working directory inside the sandbox where the agent starts.
-	// Defaults to /workspace.
+	// Defaults to /home/agent/workspace.
 	Workdir string `toml:"workdir,omitempty"`
 
 	// Restart defines the restart policy for the agent.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -26,7 +26,7 @@ harness = "claude-code"
 			cfg, err := config.ParseConfig(toml)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.Harness).To(Equal("claude-code"))
-			Expect(cfg.Workdir).To(Equal("/workspace"))
+			Expect(cfg.Workdir).To(Equal("/home/agent/workspace"))
 			Expect(cfg.Restart).To(Equal(config.RestartNo))
 			Expect(cfg.GracePeriod).To(Equal("30s"))
 			Expect(cfg.Session).To(Equal("claude-code"))

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Manager", func() {
 
 			cfg := &config.AgentConfig{
 				Harness:     "claude-code",
-				Workdir:     "/workspace",
+				Workdir:     "/home/agent/workspace",
 				Restart:     config.RestartNo,
 				GracePeriod: "30s",
 				Session:     "claude-code",
@@ -49,7 +49,7 @@ var _ = Describe("Manager", func() {
 
 			cfg := &config.AgentConfig{
 				Harness:     "opencode",
-				Workdir:     "/workspace",
+				Workdir:     "/home/agent/workspace",
 				Restart:     config.RestartNo,
 				GracePeriod: "30s",
 				Session:     "opencode",
@@ -76,7 +76,7 @@ var _ = Describe("Manager", func() {
 
 			cfg := &config.AgentConfig{
 				Harness:     "claude-code",
-				Workdir:     "/workspace",
+				Workdir:     "/home/agent/workspace",
 				Restart:     config.RestartNo,
 				GracePeriod: "30s",
 				Session:     "claude-code",


### PR DESCRIPTION
* 🔧 agent now uses `/home/agent/workspace` by default