### PR TITLE
✨ feat: gVisor + /nix/store namespace mounts

### DIFF
--- a/agentd/agentd.go
+++ b/agentd/agentd.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"maps"
 	"os"
+	"os/exec"
 	"sort"
 	"sync"
 	"time"
@@ -28,7 +29,8 @@ import (
 	"github.com/papercomputeco/agentd/pkg/api"
 	"github.com/papercomputeco/agentd/pkg/config"
 	"github.com/papercomputeco/agentd/pkg/harness"
-	"github.com/papercomputeco/agentd/pkg/manager"
+	"github.com/papercomputeco/agentd/pkg/native"
+	"github.com/papercomputeco/agentd/pkg/sandbox"
 	"github.com/papercomputeco/agentd/pkg/secrets"
 	"github.com/papercomputeco/agentd/pkg/tmux"
 )
@@ -55,12 +57,28 @@ const (
 	// tmux sessions are launched as this user so the processes execute
 	// with agent-level (not root) privileges.
 	AgentUser = "agent"
+
+	// DefaultSandboxStateDir is the default root directory for runsc state.
+	DefaultSandboxStateDir = "/run/agentd/runsc-state"
+
+	// DefaultSandboxBundleDir is the default base directory for OCI bundles.
+	DefaultSandboxBundleDir = "/run/agentd/sandboxes"
 )
+
+// AgentManager is the common interface for agent lifecycle management.
+// Both the tmux-based native manager and the gVisor sandbox manager
+// implement this interface.
+type AgentManager interface {
+	Start(ctx context.Context) error
+	Stop() error
+	IsRunning() bool
+	Status() api.AgentStatus
+}
 
 // Daemon is the agent daemon. It runs a reconciliation loop that
 // watches for configuration and secret changes, serves an API for
 // external consumers to pull agent state, and manages agent harnesses
-// in tmux sessions via a manager.
+// via either tmux sessions (native) or gVisor sandboxes (sandboxed).
 type Daemon struct {
 	configPath        string
 	secretDir         string
@@ -69,10 +87,16 @@ type Daemon struct {
 	reconcileInterval time.Duration
 	debug             bool
 
+	// Sandbox configuration.
+	runscPath        string // path to the runsc binary
+	sandboxStateDir  string // --root flag for runsc
+	sandboxBundleDir string // base directory for OCI bundles
+
 	// runtime state, guarded by mu
 	mu        sync.Mutex
-	manager   *manager.Manager
+	manager   AgentManager
 	tmux      *tmux.Server
+	runner    *sandbox.Runner
 	apiServer *api.Server
 
 	// lastConfigHash and lastSecretHash track whether config/secrets
@@ -93,7 +117,24 @@ func NewDaemon(configPath string) *Daemon {
 		apiSocketPath:     DefaultAPISocketPath,
 		tmuxSocketPath:    TmuxSocketPath,
 		reconcileInterval: DefaultReconcileInterval,
+		sandboxStateDir:   DefaultSandboxStateDir,
+		sandboxBundleDir:  DefaultSandboxBundleDir,
 	}
+}
+
+// SetRunscPath overrides the auto-detected runsc binary path.
+func (d *Daemon) SetRunscPath(path string) {
+	d.runscPath = path
+}
+
+// SetSandboxStateDir overrides the default sandbox state directory.
+func (d *Daemon) SetSandboxStateDir(dir string) {
+	d.sandboxStateDir = dir
+}
+
+// SetSandboxBundleDir overrides the default sandbox bundle directory.
+func (d *Daemon) SetSandboxBundleDir(dir string) {
+	d.sandboxBundleDir = dir
 }
 
 // SetAPISocketPath overrides the default API socket path. This is useful
@@ -140,14 +181,36 @@ func (d *Daemon) AgentStatuses() []api.AgentStatus {
 // Run starts the agentd daemon and blocks until the context is cancelled.
 // It performs the following lifecycle:
 //
-//  1. Start the tmux server
-//  2. Start the API server
-//  3. Run the reconciliation loop (reads config + secrets, converges)
-//  4. On shutdown: stop manager, stop API, stop tmux
+//  1. Initialize sandbox runner
+//  2. Start the tmux server
+//  3. Start the API server
+//  4. Run the reconciliation loop (reads config + secrets, converges)
+//  5. On shutdown: stop manager, stop API, stop tmux
 func (d *Daemon) Run(ctx context.Context) error {
 	log.Println("agentd: initializing agent manager")
 
-	// 1. Start tmux server.
+	// 1. Verify required binaries. agentd runs on stereOS (NixOS) and
+	// requires both runsc (gVisor) and nix to be available.
+	if _, err := exec.LookPath("nix"); err != nil {
+		return fmt.Errorf("nix not found in PATH: %w", err)
+	}
+
+	// Initialize sandbox runner. gVisor (runsc) is required — agentd
+	// cannot start without it since sandboxed is the default agent type.
+	runner, err := sandbox.NewRunner(d.runscPath, d.sandboxStateDir)
+	if err != nil {
+		return fmt.Errorf("sandbox runtime unavailable: %w", err)
+	}
+	d.runner = runner
+	d.runner.Debug = d.debug
+	log.Printf("agentd: sandbox runtime initialized (runsc=%s, state=%s)", runner.RunscPath, d.sandboxStateDir)
+
+	// Clean up any orphaned containers from a previous crash.
+	if err := d.runner.Cleanup(ctx); err != nil {
+		log.Printf("agentd: warning: sandbox cleanup: %v", err)
+	}
+
+	// 2. Start tmux server.
 	// Run tmux as the agent user so sessions execute with agent-level
 	// privileges and the socket is owned by agent (tmux enforces UID
 	// ownership checks on socket connections).
@@ -161,7 +224,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		_ = d.tmux.Stop()
 	}()
 
-	// 2. Start API server.
+	// 3. Start API server.
 	log.Printf("agentd: starting API server on %s", d.apiSocketPath)
 	d.apiServer = api.NewServer(d.apiSocketPath, d)
 	if err := d.apiServer.Start(); err != nil {
@@ -174,19 +237,19 @@ func (d *Daemon) Run(ctx context.Context) error {
 		_ = d.apiServer.Stop(shutdownCtx)
 	}()
 
-	// 3. Run the reconciliation loop.
+	// 4. Run the reconciliation loop.
 	log.Printf("agentd: starting reconciliation loop (interval=%s)", d.reconcileInterval)
 	d.reconcileLoop(ctx)
 
-	// 4. Graceful shutdown.
+	// 5. Graceful shutdown.
 	log.Println("agentd: shutting down")
 	d.mu.Lock()
-	sup := d.manager
+	mgr := d.manager
 	d.mu.Unlock()
 
-	if sup != nil {
+	if mgr != nil {
 		log.Println("agentd: stopping agent")
-		if err := sup.Stop(); err != nil {
+		if err := mgr.Stop(); err != nil {
 			log.Printf("agentd: error stopping agent: %v", err)
 		}
 	}
@@ -246,23 +309,23 @@ func (d *Daemon) reconcile(ctx context.Context) {
 
 	d.mu.Lock()
 	changed := configHash != d.lastConfigHash || secretHash != d.lastSecretHash
-	hasmanager := d.manager != nil
+	hasManager := d.manager != nil
 	d.mu.Unlock()
 
-	if !changed && hasmanager {
+	if !changed && hasManager {
 		// No changes and agent is already running — nothing to do.
 		return
 	}
 
 	// If the desired state changed and we have a running manager, stop it.
-	if changed && hasmanager {
+	if changed && hasManager {
 		log.Println("agentd: reconcile: config or secrets changed, restarting agent")
 		d.mu.Lock()
-		sup := d.manager
+		mgr := d.manager
 		d.manager = nil
 		d.mu.Unlock()
 
-		if err := sup.Stop(); err != nil {
+		if err := mgr.Stop(); err != nil {
 			log.Printf("agentd: reconcile: error stopping previous agent: %v", err)
 		}
 	}
@@ -286,24 +349,50 @@ func (d *Daemon) reconcile(ctx context.Context) {
 	maps.Copy(mergedEnv, secretEnv)
 	maps.Copy(mergedEnv, cfg.Env)
 
-	// Create and start manager.
-	sup := manager.NewManager(manager.Opts{
-		Config:  cfg,
-		Harness: h,
-		Tmux:    d.tmux,
-		Env:     mergedEnv,
-		Prompt:  prompt,
-		Debug:   d.debug,
-	})
+	// Create the appropriate manager based on agent type.
+	var mgr AgentManager
 
-	log.Printf("agentd: reconcile: launching agent harness=%s session=%s", cfg.Harness, cfg.Session)
-	if err := sup.Start(ctx); err != nil {
+	switch cfg.Type {
+	case config.AgentTypeSandboxed:
+		if d.runner == nil {
+			log.Println("agentd: reconcile: type=sandboxed but sandbox runner not initialized (this should not happen)")
+			return
+		}
+		mgr = sandbox.NewManager(sandbox.ManagerOpts{
+			Config:        cfg,
+			Harness:       h,
+			Runner:        d.runner,
+			Env:           mergedEnv,
+			Prompt:        prompt,
+			Debug:         d.debug,
+			BundleBaseDir: d.sandboxBundleDir,
+			ExtraPackages: cfg.ExtraPackages,
+		})
+		log.Printf("agentd: reconcile: launching sandboxed agent harness=%s", cfg.Harness)
+
+	case config.AgentTypeNative:
+		mgr = native.NewManager(native.Opts{
+			Config:  cfg,
+			Harness: h,
+			Tmux:    d.tmux,
+			Env:     mergedEnv,
+			Prompt:  prompt,
+			Debug:   d.debug,
+		})
+		log.Printf("agentd: reconcile: launching native agent harness=%s session=%s", cfg.Harness, cfg.Session)
+
+	default:
+		log.Printf("agentd: reconcile: unknown agent type %q", cfg.Type)
+		return
+	}
+
+	if err := mgr.Start(ctx); err != nil {
 		log.Printf("agentd: reconcile: error starting agent: %v", err)
 		return
 	}
 
 	d.mu.Lock()
-	d.manager = sup
+	d.manager = mgr
 	d.lastConfigHash = configHash
 	d.lastSecretHash = secretHash
 	d.mu.Unlock()

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
+	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.49.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI
 github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=
 github.com/onsi/gomega v1.39.1/go.mod h1:hL6yVALoTOxeWudERyfppUcZXjMwIMLnuSfruD2lcfg=
+github.com/opencontainers/runtime-spec v1.3.0 h1:YZupQUdctfhpZy3TM39nN9Ika5CBWT5diQ8ibYCRkxg=
+github.com/opencontainers/runtime-spec v1.3.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=

--- a/main.go
+++ b/main.go
@@ -29,6 +29,9 @@ func main() {
 	apiSocket := flag.String("api-socket", agentd.DefaultAPISocketPath, "path to agentd API unix socket")
 	secretDir := flag.String("secret-dir", agentd.SecretDir, "path to secrets directory")
 	tmuxSocket := flag.String("tmux-socket", agentd.TmuxSocketPath, "path to tmux server socket")
+	runscPath := flag.String("runsc-path", "", "path to runsc binary (auto-detected if empty)")
+	sandboxStateDir := flag.String("sandbox-state-dir", agentd.DefaultSandboxStateDir, "root directory for runsc container state")
+	sandboxBundleDir := flag.String("sandbox-bundle-dir", agentd.DefaultSandboxBundleDir, "base directory for OCI bundles")
 	debug := flag.Bool("debug", false, "enable debug logging (logs commands, env keys, captures pane output on exit)")
 	flag.Parse()
 
@@ -47,6 +50,15 @@ func main() {
 	}
 	if *tmuxSocket != agentd.TmuxSocketPath {
 		daemon.SetTmuxSocketPath(*tmuxSocket)
+	}
+	if *runscPath != "" {
+		daemon.SetRunscPath(*runscPath)
+	}
+	if *sandboxStateDir != agentd.DefaultSandboxStateDir {
+		daemon.SetSandboxStateDir(*sandboxStateDir)
+	}
+	if *sandboxBundleDir != agentd.DefaultSandboxBundleDir {
+		daemon.SetSandboxBundleDir(*sandboxBundleDir)
 	}
 	if *debug {
 		daemon.SetDebug(true)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -35,6 +35,7 @@ type AgentStatus struct {
 	Session  string `json:"session,omitempty"`
 	Restarts int    `json:"restarts"`
 	Error    string `json:"error,omitempty"`
+	Type     string `json:"type,omitempty"`
 }
 
 // HealthResponse is returned by GET /v1/health.

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -123,6 +123,24 @@ var _ = Describe("Server", func() {
 			Expect(agents[1].Running).To(BeFalse())
 			Expect(agents[1].Error).To(Equal("exited"))
 		})
+
+		It("should include the type field when set", func() {
+			provider.agents = []api.AgentStatus{
+				{Name: "claude-code", Running: true, Session: "agent-claude-code", Type: "sandboxed"},
+				{Name: "opencode", Running: true, Session: "opencode", Type: "native"},
+			}
+			startServer()
+
+			resp, err := client.Get("http://agentd/v1/agents")
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			var agents []api.AgentStatus
+			Expect(json.NewDecoder(resp.Body).Decode(&agents)).To(Succeed())
+			Expect(agents).To(HaveLen(2))
+			Expect(agents[0].Type).To(Equal("sandboxed"))
+			Expect(agents[1].Type).To(Equal("native"))
+		})
 	})
 
 	Describe("GET /v1/agents/{name}", func() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,10 +5,24 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
+)
+
+// AgentType defines how the agent process is executed.
+type AgentType string
+
+const (
+	// AgentTypeSandboxed runs the agent in a gVisor (runsc) sandbox with
+	// read-only /nix/store bind mounts and a writable tmpfs overlay.
+	AgentTypeSandboxed AgentType = "sandboxed"
+
+	// AgentTypeNative runs the agent directly on the host in a tmux
+	// session as the agent user (the original agentd behavior).
+	AgentTypeNative AgentType = "native"
 )
 
 // RestartPolicy defines the agent restart behavior.
@@ -34,6 +48,15 @@ const (
 
 	// DefaultRestart is the default restart policy.
 	DefaultRestart = RestartNo
+
+	// DefaultAgentType is the default agent execution mode.
+	DefaultAgentType = AgentTypeSandboxed
+
+	// DefaultMemory is the default memory limit for sandboxed agents.
+	DefaultMemory = "2GiB"
+
+	// DefaultPidLimit is the default PID limit for sandboxed agents.
+	DefaultPidLimit = 512
 )
 
 // harnessSet are the built-in harnesses.
@@ -46,6 +69,11 @@ var harnessSet = map[string]bool{
 
 // AgentConfig represents the [agent] section of a jcard.toml file.
 type AgentConfig struct {
+	// Type selects the agent execution mode.
+	// "sandboxed" (default) runs in a gVisor container with /nix/store sharing.
+	// "native" runs directly on the host in a tmux session.
+	Type AgentType `toml:"type,omitempty"`
+
 	// Harness is the agent harness to use.
 	// Built-in harnesses: "claude-code", "opencode", "gemini-cli", "custom".
 	Harness string `toml:"harness"`
@@ -79,8 +107,22 @@ type AgentConfig struct {
 	GracePeriod string `toml:"grace_period,omitempty"`
 
 	// Session is the tmux session name for this agent.
-	// Defaults to the harness name.
+	// Defaults to the harness name. Only used for native agents.
 	Session string `toml:"session,omitempty"`
+
+	// Memory is the memory limit for sandboxed agents (e.g. "2GiB", "512MiB").
+	// Ignored for native agents. Defaults to "2GiB".
+	Memory string `toml:"memory,omitempty"`
+
+	// PidLimit is the maximum number of processes inside a sandboxed agent.
+	// Ignored for native agents. Defaults to 512.
+	PidLimit int `toml:"pid_limit,omitempty"`
+
+	// ExtraPackages is a list of additional Nix package attribute names
+	// to install into the sandbox (e.g. ["ripgrep", "fd", "python311"]).
+	// These are resolved against the system's nixpkgs and materialized
+	// into /nix/store at agent launch time. Only used for sandboxed agents.
+	ExtraPackages []string `toml:"extra_packages,omitempty"`
 
 	// Env holds environment variables set only for the agent process.
 	Env map[string]string `toml:"env,omitempty"`
@@ -123,6 +165,9 @@ func ParseConfig(content string) (*AgentConfig, error) {
 
 // applyDefaults fills in default values for unset fields.
 func (c *AgentConfig) applyDefaults() {
+	if c.Type == "" {
+		c.Type = DefaultAgentType
+	}
 	if c.Workdir == "" {
 		c.Workdir = DefaultWorkdir
 	}
@@ -135,6 +180,14 @@ func (c *AgentConfig) applyDefaults() {
 	if c.Session == "" {
 		c.Session = c.Harness
 	}
+	if c.Type == AgentTypeSandboxed {
+		if c.Memory == "" {
+			c.Memory = DefaultMemory
+		}
+		if c.PidLimit == 0 {
+			c.PidLimit = DefaultPidLimit
+		}
+	}
 	if c.Env == nil {
 		c.Env = make(map[string]string)
 	}
@@ -142,6 +195,13 @@ func (c *AgentConfig) applyDefaults() {
 
 // Validate checks the configuration for errors.
 func (c *AgentConfig) Validate() error {
+	switch c.Type {
+	case AgentTypeSandboxed, AgentTypeNative:
+		// valid
+	default:
+		return fmt.Errorf("invalid agent.type %q: must be sandboxed or native", c.Type)
+	}
+
 	if c.Harness == "" {
 		return fmt.Errorf("agent.harness is required")
 	}
@@ -170,6 +230,28 @@ func (c *AgentConfig) Validate() error {
 		if _, err := time.ParseDuration(c.GracePeriod); err != nil {
 			return fmt.Errorf("invalid agent.grace_period %q: %w", c.GracePeriod, err)
 		}
+	}
+
+	// Sandbox-specific validation.
+	if c.Type == AgentTypeSandboxed {
+		if c.Memory != "" {
+			if _, err := ParseMemory(c.Memory); err != nil {
+				return fmt.Errorf("invalid agent.memory %q: %w", c.Memory, err)
+			}
+		}
+		if c.PidLimit < 0 {
+			return fmt.Errorf("agent.pid_limit must be >= 0, got %d", c.PidLimit)
+		}
+		for i, pkg := range c.ExtraPackages {
+			if strings.TrimSpace(pkg) == "" {
+				return fmt.Errorf("agent.extra_packages[%d] is empty", i)
+			}
+		}
+	}
+
+	// extra_packages is only valid for sandboxed agents.
+	if c.Type != AgentTypeSandboxed && len(c.ExtraPackages) > 0 {
+		return fmt.Errorf("agent.extra_packages is only supported for type=sandboxed")
 	}
 
 	return nil
@@ -204,4 +286,71 @@ func (c *AgentConfig) GraceDuration() (time.Duration, error) {
 		return 30 * time.Second, nil
 	}
 	return time.ParseDuration(c.GracePeriod)
+}
+
+// MemoryBytes parses the Memory field and returns the value in bytes.
+// Returns 0 if no memory limit is set.
+func (c *AgentConfig) MemoryBytes() (int64, error) {
+	if c.Memory == "" {
+		return 0, nil
+	}
+	return ParseMemory(c.Memory)
+}
+
+// ParseMemory parses a human-readable memory string into bytes.
+// Supported suffixes: KiB, MiB, GiB, KB, MB, GB (case-insensitive).
+// Plain integers are treated as bytes.
+func ParseMemory(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty memory string")
+	}
+
+	// Try parsing as plain integer (bytes).
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		if n < 0 {
+			return 0, fmt.Errorf("memory must be non-negative, got %d", n)
+		}
+		return n, nil
+	}
+
+	// Find where the numeric part ends and the suffix begins.
+	i := 0
+	for i < len(s) && (s[i] >= '0' && s[i] <= '9' || s[i] == '.') {
+		i++
+	}
+	if i == 0 {
+		return 0, fmt.Errorf("invalid memory format %q: no numeric value", s)
+	}
+
+	numStr := s[:i]
+	suffix := strings.ToLower(strings.TrimSpace(s[i:]))
+
+	num, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid memory format %q: %w", s, err)
+	}
+	if num < 0 {
+		return 0, fmt.Errorf("memory must be non-negative, got %s", s)
+	}
+
+	var multiplier float64
+	switch suffix {
+	case "kib":
+		multiplier = 1024
+	case "mib":
+		multiplier = 1024 * 1024
+	case "gib":
+		multiplier = 1024 * 1024 * 1024
+	case "kb":
+		multiplier = 1000
+	case "mb":
+		multiplier = 1000 * 1000
+	case "gb":
+		multiplier = 1000 * 1000 * 1000
+	default:
+		return 0, fmt.Errorf("unknown memory suffix %q in %q: use KiB, MiB, GiB, KB, MB, or GB", suffix, s)
+	}
+
+	return int64(num * multiplier), nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -26,10 +26,13 @@ harness = "claude-code"
 			cfg, err := config.ParseConfig(toml)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.Harness).To(Equal("claude-code"))
+			Expect(cfg.Type).To(Equal(config.AgentTypeSandboxed))
 			Expect(cfg.Workdir).To(Equal("/home/agent/workspace"))
 			Expect(cfg.Restart).To(Equal(config.RestartNo))
 			Expect(cfg.GracePeriod).To(Equal("30s"))
 			Expect(cfg.Session).To(Equal("claude-code"))
+			Expect(cfg.Memory).To(Equal("2GiB"))
+			Expect(cfg.PidLimit).To(Equal(512))
 		})
 
 		It("should parse a fully specified config", func() {
@@ -159,6 +162,141 @@ harness = "claude-code"
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.Harness).To(Equal("claude-code"))
 		})
+
+		It("should parse type=sandboxed explicitly", func() {
+			toml := `
+[agent]
+harness = "claude-code"
+type = "sandboxed"
+`
+			cfg, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Type).To(Equal(config.AgentTypeSandboxed))
+			Expect(cfg.Memory).To(Equal("2GiB"))
+			Expect(cfg.PidLimit).To(Equal(512))
+		})
+
+		It("should parse type=native", func() {
+			toml := `
+[agent]
+harness = "claude-code"
+type = "native"
+`
+			cfg, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Type).To(Equal(config.AgentTypeNative))
+			// Native agents do not get sandbox defaults.
+			Expect(cfg.Memory).To(BeEmpty())
+			Expect(cfg.PidLimit).To(Equal(0))
+		})
+
+		It("should reject invalid type", func() {
+			toml := `
+[agent]
+harness = "claude-code"
+type = "docker"
+`
+			_, err := config.ParseConfig(toml)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid agent.type"))
+		})
+
+		It("should parse sandbox-specific fields", func() {
+			toml := `
+[agent]
+harness = "claude-code"
+type = "sandboxed"
+memory = "4GiB"
+pid_limit = 1024
+`
+			cfg, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Memory).To(Equal("4GiB"))
+			Expect(cfg.PidLimit).To(Equal(1024))
+		})
+
+		It("should reject invalid memory format", func() {
+			toml := `
+[agent]
+harness = "claude-code"
+type = "sandboxed"
+memory = "lots"
+`
+			_, err := config.ParseConfig(toml)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid agent.memory"))
+		})
+
+		It("should reject negative pid_limit", func() {
+			toml := `
+[agent]
+harness = "claude-code"
+type = "sandboxed"
+pid_limit = -1
+`
+			_, err := config.ParseConfig(toml)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("pid_limit"))
+		})
+
+		It("should parse extra_packages for sandboxed agents", func() {
+			toml := `
+[agent]
+harness = "claude-code"
+type = "sandboxed"
+extra_packages = ["ripgrep", "fd", "python311"]
+`
+			cfg, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.ExtraPackages).To(Equal([]string{"ripgrep", "fd", "python311"}))
+		})
+
+		It("should accept empty extra_packages", func() {
+			toml := `
+[agent]
+harness = "claude-code"
+type = "sandboxed"
+extra_packages = []
+`
+			cfg, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.ExtraPackages).To(BeEmpty())
+		})
+
+		It("should accept sandboxed agent without extra_packages", func() {
+			toml := `
+[agent]
+harness = "claude-code"
+type = "sandboxed"
+`
+			cfg, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.ExtraPackages).To(BeNil())
+		})
+
+		It("should reject extra_packages with empty string entries", func() {
+			toml := `
+[agent]
+harness = "claude-code"
+type = "sandboxed"
+extra_packages = ["ripgrep", "", "fd"]
+`
+			_, err := config.ParseConfig(toml)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("extra_packages[1] is empty"))
+		})
+
+		It("should reject extra_packages for native agents", func() {
+			toml := `
+[agent]
+harness = "claude-code"
+type = "native"
+extra_packages = ["ripgrep"]
+`
+			_, err := config.ParseConfig(toml)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("extra_packages is only supported for type=sandboxed"))
+		})
 	})
 
 	Describe("LoadConfig", func() {
@@ -265,6 +403,88 @@ prompt = "hello world"
 			d, err := cfg.GraceDuration()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(d.Minutes()).To(Equal(1.0))
+		})
+	})
+
+	Describe("ParseMemory", func() {
+		It("should parse GiB", func() {
+			n, err := config.ParseMemory("2GiB")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(2 * 1024 * 1024 * 1024)))
+		})
+
+		It("should parse MiB", func() {
+			n, err := config.ParseMemory("512MiB")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(512 * 1024 * 1024)))
+		})
+
+		It("should parse KiB", func() {
+			n, err := config.ParseMemory("1024KiB")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(1024 * 1024)))
+		})
+
+		It("should parse GB (decimal)", func() {
+			n, err := config.ParseMemory("1GB")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(1000 * 1000 * 1000)))
+		})
+
+		It("should parse MB (decimal)", func() {
+			n, err := config.ParseMemory("500MB")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(500 * 1000 * 1000)))
+		})
+
+		It("should parse plain bytes", func() {
+			n, err := config.ParseMemory("1073741824")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(1073741824)))
+		})
+
+		It("should be case-insensitive", func() {
+			n, err := config.ParseMemory("2gib")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(2 * 1024 * 1024 * 1024)))
+		})
+
+		It("should reject empty string", func() {
+			_, err := config.ParseMemory("")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should reject unknown suffix", func() {
+			_, err := config.ParseMemory("2TiB")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unknown memory suffix"))
+		})
+
+		It("should reject non-numeric value", func() {
+			_, err := config.ParseMemory("lots")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should parse fractional values", func() {
+			n, err := config.ParseMemory("1.5GiB")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(1.5 * 1024 * 1024 * 1024)))
+		})
+	})
+
+	Describe("MemoryBytes", func() {
+		It("should return 0 when memory is empty", func() {
+			cfg := &config.AgentConfig{Harness: "claude-code"}
+			n, err := cfg.MemoryBytes()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(BeZero())
+		})
+
+		It("should parse the memory field", func() {
+			cfg := &config.AgentConfig{Harness: "claude-code", Memory: "2GiB"}
+			n, err := cfg.MemoryBytes()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(2 * 1024 * 1024 * 1024)))
 		})
 	})
 })

--- a/pkg/native/manager.go
+++ b/pkg/native/manager.go
@@ -1,8 +1,8 @@
-// Package manager manages the lifecycle of an agent process running
+// Package native manages the lifecycle of a native agent process running
 // in a tmux session. It handles starting the agent, monitoring its health,
 // implementing restart policies (no, on-failure, always), enforcing
 // timeouts, and coordinating graceful shutdown.
-package manager
+package native
 
 import (
 	"context"
@@ -124,6 +124,7 @@ func (s *Manager) Status() api.AgentStatus {
 		Session:  s.config.Session,
 		Restarts: s.restarts,
 		Error:    s.lastErr,
+		Type:     "native",
 	}
 }
 

--- a/pkg/native/manager_test.go
+++ b/pkg/native/manager_test.go
@@ -1,4 +1,4 @@
-package manager_test
+package native_test
 
 import (
 	"testing"
@@ -8,12 +8,12 @@ import (
 
 	"github.com/papercomputeco/agentd/pkg/config"
 	"github.com/papercomputeco/agentd/pkg/harness"
-	"github.com/papercomputeco/agentd/pkg/manager"
+	"github.com/papercomputeco/agentd/pkg/native"
 )
 
-func TestManager(t *testing.T) {
+func TestNative(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Manager Suite")
+	RunSpecs(t, "Native Suite")
 }
 
 var _ = Describe("Manager", func() {
@@ -30,7 +30,7 @@ var _ = Describe("Manager", func() {
 				Session:     "claude-code",
 			}
 
-			m := manager.NewManager(manager.Opts{
+			m := native.NewManager(native.Opts{
 				Config:  cfg,
 				Harness: h,
 				Env:     map[string]string{"FOO": "bar"},
@@ -55,7 +55,7 @@ var _ = Describe("Manager", func() {
 				Session:     "opencode",
 			}
 
-			m := manager.NewManager(manager.Opts{
+			m := native.NewManager(native.Opts{
 				Config:  cfg,
 				Harness: h,
 			})
@@ -82,7 +82,7 @@ var _ = Describe("Manager", func() {
 				Session:     "claude-code",
 			}
 
-			m := manager.NewManager(manager.Opts{
+			m := native.NewManager(native.Opts{
 				Config:  cfg,
 				Harness: h,
 			})

--- a/pkg/sandbox/closure.go
+++ b/pkg/sandbox/closure.go
@@ -1,0 +1,67 @@
+package sandbox
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const (
+	// DefaultClosureManifest is the well-known path where stereOS writes
+	// the pre-computed sandbox closure at build time.
+	DefaultClosureManifest = "/etc/stereos/sandbox-closure.txt"
+)
+
+// ComputeClosureFromManifest reads a pre-computed closure manifest file.
+// Each line is expected to be a /nix/store path. Empty lines and lines
+// starting with # are skipped.
+func ComputeClosureFromManifest(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening manifest %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var paths []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if !strings.HasPrefix(line, "/nix/store/") {
+			continue
+		}
+		paths = append(paths, line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading manifest %s: %w", path, err)
+	}
+
+	return paths, nil
+}
+
+// nixStoreQueryRequisites runs nix-store -qR on a path and returns the
+// list of store paths in the closure.
+func nixStoreQueryRequisites(ctx context.Context, path string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "nix-store", "-qR", path)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("nix-store -qR %s: %w", path, err)
+	}
+
+	var paths []string
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" && strings.HasPrefix(line, "/nix/store/") {
+			paths = append(paths, line)
+		}
+	}
+
+	return paths, nil
+}

--- a/pkg/sandbox/manager.go
+++ b/pkg/sandbox/manager.go
@@ -1,0 +1,466 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/papercomputeco/agentd/pkg/api"
+	"github.com/papercomputeco/agentd/pkg/config"
+	"github.com/papercomputeco/agentd/pkg/harness"
+)
+
+const (
+	// defaultPollInterval is how often the manager checks if the
+	// sandbox is still running.
+	defaultPollInterval = 2 * time.Second
+
+	// restartBackoff is the delay between restart attempts.
+	restartBackoff = 3 * time.Second
+)
+
+// ManagerOpts holds configuration for creating a new sandbox Manager.
+type ManagerOpts struct {
+	Config              *config.AgentConfig
+	Harness             harness.Harness
+	Runner              *Runner
+	Env                 map[string]string // merged secrets + agent env
+	Prompt              string            // resolved prompt
+	Debug               bool
+	ClosureManifestPath string   // path to pre-computed closure manifest
+	BundleBaseDir       string   // base directory for sandbox bundles
+	ExtraPackages       []string // additional nixpkgs attribute names to install
+}
+
+// Manager manages a single sandboxed agent process lifecycle.
+// It is the gVisor counterpart to the tmux-based pkg/native.Manager.
+type Manager struct {
+	config              *config.AgentConfig
+	harness             harness.Harness
+	runner              *Runner
+	env                 map[string]string
+	prompt              string
+	debug               bool
+	closureManifestPath string
+	bundleBaseDir       string
+	extraPackages       []string
+
+	mu           sync.Mutex
+	running      bool
+	restarts     int
+	lastErr      string
+	cancel       context.CancelFunc
+	done         chan struct{}
+	sandboxID    string
+	bundleDir    string
+	closureCache []string // cached closure paths
+}
+
+// NewManager creates a new sandbox manager with the given options.
+func NewManager(opts ManagerOpts) *Manager {
+	bundleBase := opts.BundleBaseDir
+	if bundleBase == "" {
+		bundleBase = "/run/agentd/sandboxes"
+	}
+	manifestPath := opts.ClosureManifestPath
+	if manifestPath == "" {
+		manifestPath = DefaultClosureManifest
+	}
+
+	return &Manager{
+		config:              opts.Config,
+		harness:             opts.Harness,
+		runner:              opts.Runner,
+		env:                 opts.Env,
+		prompt:              opts.Prompt,
+		debug:               opts.Debug,
+		closureManifestPath: manifestPath,
+		bundleBaseDir:       bundleBase,
+		extraPackages:       opts.ExtraPackages,
+		done:                make(chan struct{}),
+	}
+}
+
+// Start launches the sandboxed agent and begins the monitoring loop.
+// It runs until the context is cancelled or the agent exits and the
+// restart policy does not call for a restart.
+func (m *Manager) Start(ctx context.Context) error {
+	ctx, m.cancel = context.WithCancel(ctx)
+
+	// Apply timeout if configured.
+	timeout, err := m.config.TimeoutDuration()
+	if err != nil {
+		return fmt.Errorf("parsing timeout: %w", err)
+	}
+	if timeout > 0 {
+		ctx, m.cancel = context.WithTimeout(ctx, timeout)
+	}
+
+	// Compute the Nix closure (cached for restarts).
+	if err := m.ensureClosure(ctx); err != nil {
+		return fmt.Errorf("computing closure: %w", err)
+	}
+
+	// Launch the initial sandbox.
+	if err := m.launchSandbox(ctx); err != nil {
+		return fmt.Errorf("launching sandbox: %w", err)
+	}
+
+	go m.run(ctx)
+	return nil
+}
+
+// Stop gracefully stops the sandboxed agent.
+func (m *Manager) Stop() error {
+	m.mu.Lock()
+	if m.cancel != nil {
+		m.cancel()
+	}
+	m.mu.Unlock()
+
+	// Wait for the monitoring loop to finish.
+	<-m.done
+
+	return m.stopSandbox()
+}
+
+// IsRunning returns whether the sandbox is currently running.
+func (m *Manager) IsRunning() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.running
+}
+
+// Status returns the current agent status suitable for the API.
+func (m *Manager) Status() api.AgentStatus {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return api.AgentStatus{
+		Name:     m.harness.Name(),
+		Running:  m.running,
+		Session:  m.sandboxID, // sandbox ID serves as the "session" identifier
+		Restarts: m.restarts,
+		Error:    m.lastErr,
+		Type:     "sandboxed",
+	}
+}
+
+// Restarts returns the number of times the sandbox has been restarted.
+func (m *Manager) Restarts() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.restarts
+}
+
+// ensureClosure loads the base closure from the manifest and
+// materializes any extra packages. The result is cached and reused
+// across restarts since store paths don't change during agentd's
+// lifetime.
+func (m *Manager) ensureClosure(ctx context.Context) error {
+	if len(m.closureCache) > 0 {
+		return nil
+	}
+
+	// 1. Load the base closure from the manifest (required).
+	basePaths, err := ComputeClosureFromManifest(m.closureManifestPath)
+	if err != nil {
+		return fmt.Errorf("loading base closure manifest: %w", err)
+	}
+	if len(basePaths) == 0 {
+		return fmt.Errorf("base closure manifest %s is empty", m.closureManifestPath)
+	}
+	log.Printf("sandbox: loaded %d store paths from manifest %s", len(basePaths), m.closureManifestPath)
+
+	// 2. Materialize extra packages if configured.
+	var extraPaths []string
+	if len(m.extraPackages) > 0 {
+		log.Printf("sandbox: materializing %d extra packages", len(m.extraPackages))
+		extraPaths, err = MaterializePackages(ctx, m.extraPackages)
+		if err != nil {
+			return fmt.Errorf("materializing extra packages: %w", err)
+		}
+		log.Printf("sandbox: extra packages contributed %d store paths", len(extraPaths))
+	}
+
+	// 3. Merge and cache.
+	m.closureCache = MergePaths(basePaths, extraPaths)
+	log.Printf("sandbox: total closure: %d store paths", len(m.closureCache))
+	return nil
+}
+
+// launchSandbox creates an OCI bundle and runs the sandbox.
+func (m *Manager) launchSandbox(ctx context.Context) error {
+	// Generate a deterministic sandbox ID.
+	m.sandboxID = fmt.Sprintf("agent-%s", m.harness.Name())
+
+	// Create the bundle directory.
+	m.bundleDir = filepath.Join(m.bundleBaseDir, m.sandboxID)
+	rootfsDir := filepath.Join(m.bundleDir, "rootfs")
+
+	if err := os.MkdirAll(rootfsDir, 0755); err != nil {
+		return fmt.Errorf("creating bundle directory: %w", err)
+	}
+
+	// Prepare the rootfs.
+	if err := PrepareRootfs(rootfsDir, m.closureCache); err != nil {
+		return fmt.Errorf("preparing rootfs: %w", err)
+	}
+
+	// Build the harness command.
+	bin, args := m.harness.BuildCommand(m.prompt)
+
+	if m.debug {
+		if len(args) > 0 {
+			log.Printf("sandbox: [debug] command: %s %s", bin, strings.Join(args, " "))
+		} else {
+			log.Printf("sandbox: [debug] command: %s", bin)
+		}
+		log.Printf("sandbox: [debug] workdir: %s", m.config.Workdir)
+		log.Printf("sandbox: [debug] env keys: %s", envKeys(m.env))
+		log.Printf("sandbox: [debug] sandbox ID: %s", m.sandboxID)
+		log.Printf("sandbox: [debug] bundle dir: %s", m.bundleDir)
+		log.Printf("sandbox: [debug] closure: %d store paths", len(m.closureCache))
+	}
+
+	// Parse memory limit.
+	memBytes, err := m.config.MemoryBytes()
+	if err != nil {
+		return fmt.Errorf("parsing memory limit: %w", err)
+	}
+
+	// Generate the OCI spec.
+	sandboxCfg := &Config{
+		ID:          m.sandboxID,
+		Command:     bin,
+		Args:        args,
+		Env:         m.env,
+		Workdir:     m.config.Workdir,
+		StorePaths:  m.closureCache,
+		MemoryLimit: memBytes,
+		PidLimit:    int64(m.config.PidLimit),
+		Hostname:    m.sandboxID,
+	}
+
+	spec, err := GenerateSpec(sandboxCfg)
+	if err != nil {
+		return fmt.Errorf("generating OCI spec: %w", err)
+	}
+
+	specJSON, err := MarshalSpec(spec)
+	if err != nil {
+		return fmt.Errorf("marshaling OCI spec: %w", err)
+	}
+
+	configPath := filepath.Join(m.bundleDir, "config.json")
+	if err := os.WriteFile(configPath, specJSON, 0644); err != nil {
+		return fmt.Errorf("writing config.json: %w", err)
+	}
+
+	// Run the sandbox.
+	if err := m.runner.Run(ctx, m.sandboxID, m.bundleDir); err != nil {
+		return fmt.Errorf("runsc run: %w", err)
+	}
+
+	// Verify it's running.
+	running, err := m.runner.IsRunning(ctx, m.sandboxID)
+	if err != nil {
+		return fmt.Errorf("checking sandbox state: %w", err)
+	}
+	if !running {
+		return fmt.Errorf("sandbox %s failed to start", m.sandboxID)
+	}
+
+	m.mu.Lock()
+	m.running = true
+	m.lastErr = ""
+	m.mu.Unlock()
+
+	log.Printf("sandbox: agent %q launched in sandbox %q", m.harness.Name(), m.sandboxID)
+	return nil
+}
+
+// stopSandbox gracefully stops and cleans up the running sandbox.
+func (m *Manager) stopSandbox() error {
+	m.mu.Lock()
+	wasRunning := m.running
+	sandboxID := m.sandboxID
+	bundleDir := m.bundleDir
+	m.mu.Unlock()
+
+	if !wasRunning {
+		return nil
+	}
+
+	ctx := context.Background()
+
+	// Check if the sandbox is still running.
+	running, _ := m.runner.IsRunning(ctx, sandboxID)
+	if !running {
+		m.mu.Lock()
+		m.running = false
+		m.mu.Unlock()
+		// Clean up the bundle directory.
+		_ = m.runner.Delete(ctx, sandboxID)
+		_ = os.RemoveAll(bundleDir)
+		return nil
+	}
+
+	grace, err := m.config.GraceDuration()
+	if err != nil {
+		grace = 30 * time.Second
+	}
+
+	log.Printf("sandbox: sending SIGTERM to sandbox %q, grace period %s", sandboxID, grace)
+
+	// Send SIGTERM.
+	if err := m.runner.Kill(ctx, sandboxID, "SIGTERM"); err != nil {
+		log.Printf("sandbox: error sending SIGTERM to %q: %v", sandboxID, err)
+	}
+
+	// Wait for the sandbox to exit within the grace period.
+	deadline := time.After(grace)
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	exited := false
+	for !exited {
+		select {
+		case <-deadline:
+			log.Printf("sandbox: grace period expired, sending SIGKILL to %q", sandboxID)
+			_ = m.runner.Kill(ctx, sandboxID, "SIGKILL")
+			// Give a moment for SIGKILL to take effect.
+			time.Sleep(1 * time.Second)
+			exited = true
+		case <-ticker.C:
+			running, _ := m.runner.IsRunning(ctx, sandboxID)
+			if !running {
+				log.Printf("sandbox: sandbox %q exited gracefully", sandboxID)
+				exited = true
+			}
+		}
+	}
+
+	// Delete the container and clean up the bundle.
+	if err := m.runner.Delete(ctx, sandboxID); err != nil {
+		log.Printf("sandbox: error deleting container %q: %v", sandboxID, err)
+	}
+	if err := os.RemoveAll(bundleDir); err != nil {
+		log.Printf("sandbox: error removing bundle %q: %v", bundleDir, err)
+	}
+
+	m.mu.Lock()
+	m.running = false
+	m.mu.Unlock()
+
+	return nil
+}
+
+// run monitors the sandbox and handles restarts per the configured
+// restart policy.
+func (m *Manager) run(ctx context.Context) {
+	defer close(m.done)
+
+	for {
+		// Wait for the sandbox to exit or context to be cancelled.
+		exitCh := make(chan struct{})
+		go func() {
+			m.waitForExit(ctx)
+			close(exitCh)
+		}()
+
+		select {
+		case <-ctx.Done():
+			// Shutdown requested — Stop() handles cleanup.
+			return
+
+		case <-exitCh:
+			m.mu.Lock()
+			m.running = false
+			m.mu.Unlock()
+
+			log.Printf("sandbox: agent %q exited", m.harness.Name())
+
+			if !m.shouldRestart() {
+				log.Printf("sandbox: not restarting agent %q (policy=%s, restarts=%d)",
+					m.harness.Name(), m.config.Restart, m.restarts)
+				return
+			}
+
+			m.restarts++
+			log.Printf("sandbox: restarting agent %q (attempt %d)", m.harness.Name(), m.restarts)
+
+			// Clean up old sandbox before restart.
+			cleanupCtx := context.Background()
+			_ = m.runner.Delete(cleanupCtx, m.sandboxID)
+			_ = os.RemoveAll(m.bundleDir)
+
+			// Backoff before restart.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(restartBackoff):
+			}
+
+			if err := m.launchSandbox(ctx); err != nil {
+				log.Printf("sandbox: failed to restart agent %q: %v", m.harness.Name(), err)
+				m.mu.Lock()
+				m.lastErr = err.Error()
+				m.mu.Unlock()
+				return
+			}
+		}
+	}
+}
+
+// waitForExit polls runsc state until the sandbox is no longer running.
+func (m *Manager) waitForExit(ctx context.Context) {
+	ticker := time.NewTicker(defaultPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			running, _ := m.runner.IsRunning(ctx, m.sandboxID)
+			if !running {
+				return
+			}
+		}
+	}
+}
+
+// shouldRestart evaluates whether the sandbox should be restarted based
+// on the configured restart policy and restart count.
+func (m *Manager) shouldRestart() bool {
+	switch m.config.Restart {
+	case config.RestartNo:
+		return false
+
+	case config.RestartOnFailure, config.RestartAlways:
+		if m.config.MaxRestarts > 0 && m.restarts >= m.config.MaxRestarts {
+			return false
+		}
+		return true
+
+	default:
+		return false
+	}
+}
+
+// envKeys returns a sorted, comma-separated list of environment variable
+// names. Values are omitted because they may contain secrets.
+func envKeys(env map[string]string) string {
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
+}

--- a/pkg/sandbox/oci.go
+++ b/pkg/sandbox/oci.go
@@ -1,0 +1,191 @@
+package sandbox
+
+import (
+	"encoding/json"
+	"fmt"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+const (
+	// agentUID is the uid of the agent user inside the sandbox.
+	agentUID = 1000
+
+	// agentGID is the gid of the agent group inside the sandbox.
+	agentGID = 1000
+)
+
+// GenerateSpec produces an OCI runtime specification for a sandbox.
+//
+// The spec configures:
+//   - Process running as uid/gid 1000 (agent) with the given command
+//   - Standard mounts: /proc, /dev (tmpfs), /sys (ro), /tmp (tmpfs), /home/agent (tmpfs)
+//   - Read-only bind mounts for every /nix/store path in the closure
+//   - Linux namespaces: pid, ipc, uts, mount (NO network — uses host network)
+//   - Resource limits: memory and PID limits from config
+func GenerateSpec(cfg *Config) (*specs.Spec, error) {
+	if cfg.ID == "" {
+		return nil, fmt.Errorf("sandbox ID is required")
+	}
+	if cfg.Command == "" {
+		return nil, fmt.Errorf("sandbox command is required")
+	}
+
+	// Build process args: command followed by any arguments.
+	args := make([]string, 0, 1+len(cfg.Args))
+	args = append(args, cfg.Command)
+	args = append(args, cfg.Args...)
+
+	// Build environment variable list.
+	env := buildEnvList(cfg.Env)
+
+	// Determine working directory.
+	cwd := cfg.Workdir
+	if cwd == "" {
+		cwd = "/home/agent"
+	}
+
+	// Determine hostname.
+	hostname := cfg.Hostname
+	if hostname == "" {
+		hostname = cfg.ID
+	}
+
+	// Build the mount list.
+	mounts := buildMounts(cfg.StorePaths)
+
+	// Build Linux config with namespaces and resource limits.
+	linux := buildLinux(cfg.MemoryLimit, cfg.PidLimit)
+
+	spec := &specs.Spec{
+		Version: specs.Version,
+		Process: &specs.Process{
+			Terminal: false,
+			User: specs.User{
+				UID: agentUID,
+				GID: agentGID,
+			},
+			Args: args,
+			Env:  env,
+			Cwd:  cwd,
+		},
+		Root: &specs.Root{
+			Path:     "rootfs",
+			Readonly: false,
+		},
+		Hostname: hostname,
+		Mounts:   mounts,
+		Linux:    linux,
+	}
+
+	return spec, nil
+}
+
+// MarshalSpec serializes an OCI spec to indented JSON suitable for
+// writing to a config.json file in an OCI bundle.
+func MarshalSpec(spec *specs.Spec) ([]byte, error) {
+	return json.MarshalIndent(spec, "", "  ")
+}
+
+// buildEnvList converts a map of environment variables to the OCI
+// format: a slice of "KEY=VALUE" strings. Standard variables are
+// always included.
+func buildEnvList(env map[string]string) []string {
+	// Start with standard environment variables.
+	result := []string{
+		"HOME=/home/agent",
+		"PATH=/bin:/usr/bin",
+		"TERM=xterm-256color",
+		"USER=agent",
+	}
+
+	// Append user-specified variables. These can override the defaults
+	// since runsc uses the last value for duplicate keys.
+	for k, v := range env {
+		result = append(result, k+"="+v)
+	}
+
+	return result
+}
+
+// buildMounts creates the OCI mount list with standard filesystem mounts
+// and read-only bind mounts for each /nix/store path.
+func buildMounts(storePaths []string) []specs.Mount {
+	mounts := []specs.Mount{
+		{
+			Destination: "/proc",
+			Type:        "proc",
+			Source:      "proc",
+		},
+		{
+			Destination: "/dev",
+			Type:        "tmpfs",
+			Source:      "tmpfs",
+			Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+		},
+		{
+			Destination: "/sys",
+			Type:        "sysfs",
+			Source:      "sysfs",
+			Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+		},
+		{
+			Destination: "/tmp",
+			Type:        "tmpfs",
+			Source:      "tmpfs",
+			Options:     []string{"nosuid", "nodev", "size=512m"},
+		},
+		{
+			Destination: "/home/agent",
+			Type:        "tmpfs",
+			Source:      "tmpfs",
+			Options:     []string{"nosuid", "nodev", "size=512m"},
+		},
+	}
+
+	// Add read-only bind mounts for each /nix/store path.
+	for _, storePath := range storePaths {
+		mounts = append(mounts, specs.Mount{
+			Destination: storePath,
+			Type:        "bind",
+			Source:      storePath,
+			Options:     []string{"rbind", "ro"},
+		})
+	}
+
+	return mounts
+}
+
+// buildLinux creates the Linux-specific portion of the OCI spec with
+// namespace and resource limit configuration.
+func buildLinux(memoryLimit, pidLimit int64) *specs.Linux {
+	linux := &specs.Linux{
+		Namespaces: []specs.LinuxNamespace{
+			{Type: specs.PIDNamespace},
+			{Type: specs.IPCNamespace},
+			{Type: specs.UTSNamespace},
+			{Type: specs.MountNamespace},
+			// NOTE: No network namespace — we use host networking.
+			// The stereOS VM is already the network boundary.
+		},
+	}
+
+	// Add resource limits if specified.
+	if memoryLimit > 0 || pidLimit > 0 {
+		linux.Resources = &specs.LinuxResources{}
+
+		if memoryLimit > 0 {
+			linux.Resources.Memory = &specs.LinuxMemory{
+				Limit: &memoryLimit,
+			}
+		}
+
+		if pidLimit > 0 {
+			linux.Resources.Pids = &specs.LinuxPids{
+				Limit: &pidLimit,
+			}
+		}
+	}
+
+	return linux
+}

--- a/pkg/sandbox/packages.go
+++ b/pkg/sandbox/packages.go
@@ -1,0 +1,101 @@
+package sandbox
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// MaterializePackages resolves bare Nix package attribute names to
+// /nix/store paths by building each package via nix build and computing
+// its transitive closure. All packages must build successfully or an
+// error is returned.
+//
+// Package names are resolved against the system's nixpkgs flake
+// (e.g. "ripgrep" becomes "nixpkgs#ripgrep").
+func MaterializePackages(ctx context.Context, packages []string) ([]string, error) {
+	if len(packages) == 0 {
+		return nil, nil
+	}
+
+	seen := make(map[string]bool)
+
+	for _, pkg := range packages {
+		ref := "nixpkgs#" + pkg
+
+		log.Printf("sandbox: materializing package %s", ref)
+
+		outPaths, err := nixBuild(ctx, ref)
+		if err != nil {
+			return nil, fmt.Errorf("building package %q: %w", pkg, err)
+		}
+
+		// For each output path, compute the full closure.
+		for _, outPath := range outPaths {
+			closure, err := nixStoreQueryRequisites(ctx, outPath)
+			if err != nil {
+				return nil, fmt.Errorf("computing closure for %s (package %q): %w", outPath, pkg, err)
+			}
+			for _, p := range closure {
+				seen[p] = true
+			}
+		}
+	}
+
+	return sortedKeys(seen), nil
+}
+
+// MergePaths merges two lists of /nix/store paths, deduplicates, and
+// returns the result sorted.
+func MergePaths(base, extra []string) []string {
+	seen := make(map[string]bool, len(base)+len(extra))
+	for _, p := range base {
+		seen[p] = true
+	}
+	for _, p := range extra {
+		seen[p] = true
+	}
+	return sortedKeys(seen)
+}
+
+// nixBuild runs "nix build --no-link --print-out-paths <ref>" and returns
+// the output store paths (one per line).
+func nixBuild(ctx context.Context, ref string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "nix", "build", "--no-link", "--print-out-paths", ref)
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("nix build %s: %w\nstderr: %s", ref, err, string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("nix build %s: %w", ref, err)
+	}
+
+	var paths []string
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" && strings.HasPrefix(line, "/nix/store/") {
+			paths = append(paths, line)
+		}
+	}
+
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("nix build %s produced no output paths", ref)
+	}
+
+	return paths, nil
+}
+
+// sortedKeys returns the keys of a map as a sorted slice.
+func sortedKeys(m map[string]bool) []string {
+	result := make([]string, 0, len(m))
+	for k := range m {
+		result = append(result, k)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/pkg/sandbox/packages_test.go
+++ b/pkg/sandbox/packages_test.go
@@ -1,0 +1,82 @@
+package sandbox_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/agentd/pkg/sandbox"
+)
+
+var _ = Describe("Packages", func() {
+	Describe("MergePaths", func() {
+		It("should merge two disjoint lists", func() {
+			base := []string{"/nix/store/aaa-bash-5.2", "/nix/store/bbb-glibc-2.39"}
+			extra := []string{"/nix/store/ccc-ripgrep-14", "/nix/store/ddd-fd-9"}
+
+			result := sandbox.MergePaths(base, extra)
+			Expect(result).To(HaveLen(4))
+			Expect(result).To(Equal([]string{
+				"/nix/store/aaa-bash-5.2",
+				"/nix/store/bbb-glibc-2.39",
+				"/nix/store/ccc-ripgrep-14",
+				"/nix/store/ddd-fd-9",
+			}))
+		})
+
+		It("should deduplicate overlapping paths", func() {
+			base := []string{"/nix/store/aaa-bash-5.2", "/nix/store/bbb-glibc-2.39"}
+			extra := []string{"/nix/store/bbb-glibc-2.39", "/nix/store/ccc-ripgrep-14"}
+
+			result := sandbox.MergePaths(base, extra)
+			Expect(result).To(HaveLen(3))
+			Expect(result).To(Equal([]string{
+				"/nix/store/aaa-bash-5.2",
+				"/nix/store/bbb-glibc-2.39",
+				"/nix/store/ccc-ripgrep-14",
+			}))
+		})
+
+		It("should return sorted results", func() {
+			base := []string{"/nix/store/zzz-vim-9", "/nix/store/aaa-bash-5.2"}
+			extra := []string{"/nix/store/mmm-git-2.43"}
+
+			result := sandbox.MergePaths(base, extra)
+			Expect(result).To(Equal([]string{
+				"/nix/store/aaa-bash-5.2",
+				"/nix/store/mmm-git-2.43",
+				"/nix/store/zzz-vim-9",
+			}))
+		})
+
+		It("should handle empty base", func() {
+			extra := []string{"/nix/store/ccc-ripgrep-14"}
+			result := sandbox.MergePaths(nil, extra)
+			Expect(result).To(Equal([]string{"/nix/store/ccc-ripgrep-14"}))
+		})
+
+		It("should handle empty extra", func() {
+			base := []string{"/nix/store/aaa-bash-5.2"}
+			result := sandbox.MergePaths(base, nil)
+			Expect(result).To(Equal([]string{"/nix/store/aaa-bash-5.2"}))
+		})
+
+		It("should handle both empty", func() {
+			result := sandbox.MergePaths(nil, nil)
+			Expect(result).To(BeEmpty())
+		})
+	})
+
+	Describe("MaterializePackages", func() {
+		It("should return nil for empty input", func() {
+			result, err := sandbox.MaterializePackages(nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+
+		It("should return nil for zero-length input", func() {
+			result, err := sandbox.MaterializePackages(nil, []string{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+	})
+})

--- a/pkg/sandbox/rootfs.go
+++ b/pkg/sandbox/rootfs.go
@@ -1,0 +1,127 @@
+package sandbox
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Standard directories to create in the rootfs.
+var rootfsDirs = []string{
+	"bin",
+	"dev",
+	"etc",
+	"home/agent",
+	"proc",
+	"sys",
+	"tmp",
+	"var",
+	"run",
+	"nix/store",
+	"usr/bin",
+}
+
+const etcPasswd = `root:x:0:0:root:/root:/bin/bash
+agent:x:1000:1000:AI Agent:/home/agent:/bin/bash
+`
+
+const etcGroup = `root:x:0:
+agent:x:1000:
+`
+
+// PrepareRootfs creates a minimal rootfs directory structure at the given
+// path. It creates standard directories, writes minimal /etc files, and
+// symlinks binaries from /nix/store paths into /bin.
+func PrepareRootfs(rootfsDir string, storePaths []string) error {
+	// Create the directory skeleton.
+	for _, dir := range rootfsDirs {
+		if err := os.MkdirAll(filepath.Join(rootfsDir, dir), 0755); err != nil {
+			return fmt.Errorf("creating directory %s: %w", dir, err)
+		}
+	}
+
+	// Write minimal /etc files.
+	etcFiles := map[string]string{
+		"etc/passwd":      etcPasswd,
+		"etc/group":       etcGroup,
+		"etc/hostname":    "sandbox\n",
+		"etc/hosts":       "127.0.0.1 localhost\n::1 localhost\n",
+		"etc/resolv.conf": "nameserver 8.8.8.8\nnameserver 8.8.4.4\n",
+	}
+
+	for name, content := range etcFiles {
+		path := filepath.Join(rootfsDir, name)
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", name, err)
+		}
+	}
+
+	// Symlink binaries from /nix/store paths into /rootfs/bin/.
+	binDir := filepath.Join(rootfsDir, "bin")
+	if err := symlinkBinaries(binDir, storePaths); err != nil {
+		return fmt.Errorf("symlinking binaries: %w", err)
+	}
+
+	return nil
+}
+
+// symlinkBinaries scans /nix/store paths for bin/ directories and creates
+// symlinks in the rootfs /bin for each executable found.
+func symlinkBinaries(binDir string, storePaths []string) error {
+	bashLinked := false
+
+	for _, storePath := range storePaths {
+		nixBinDir := filepath.Join(storePath, "bin")
+		entries, err := os.ReadDir(nixBinDir)
+		if err != nil {
+			// Not every store path has a bin/ directory.
+			continue
+		}
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+
+			srcPath := filepath.Join(nixBinDir, entry.Name())
+
+			// Check if the file is executable.
+			info, err := os.Stat(srcPath)
+			if err != nil {
+				continue
+			}
+			if info.Mode()&0111 == 0 {
+				continue
+			}
+
+			linkPath := filepath.Join(binDir, entry.Name())
+
+			// Don't overwrite existing symlinks (first one wins).
+			if _, err := os.Lstat(linkPath); err == nil {
+				continue
+			}
+
+			if err := os.Symlink(srcPath, linkPath); err != nil {
+				// Non-fatal: log and continue.
+				continue
+			}
+
+			// Track if we've linked bash for the /bin/sh symlink.
+			if entry.Name() == "bash" {
+				bashLinked = true
+			}
+		}
+	}
+
+	// Ensure /bin/sh exists as a symlink to bash.
+	if bashLinked {
+		shPath := filepath.Join(binDir, "sh")
+		if _, err := os.Lstat(shPath); os.IsNotExist(err) {
+			bashPath := filepath.Join(binDir, "bash")
+			// Symlink sh -> bash (relative within /bin).
+			_ = os.Symlink(bashPath, shPath)
+		}
+	}
+
+	return nil
+}

--- a/pkg/sandbox/runsc.go
+++ b/pkg/sandbox/runsc.go
@@ -1,0 +1,231 @@
+package sandbox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const (
+	// DefaultPlatform is the gVisor platform used for sandboxes.
+	// systrap is the fastest on modern kernels.
+	DefaultPlatform = "systrap"
+)
+
+// ContainerState represents the JSON output of runsc state.
+type ContainerState struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	PID    int    `json:"pid"`
+	Bundle string `json:"bundle"`
+}
+
+// Runner wraps the runsc binary for container lifecycle management.
+type Runner struct {
+	// RunscPath is the path to the runsc binary.
+	RunscPath string
+
+	// StateDir is the root directory for runsc state (--root flag).
+	StateDir string
+
+	// Platform is the gVisor platform to use (default: systrap).
+	Platform string
+
+	// Debug enables verbose logging of runsc commands.
+	Debug bool
+}
+
+// NewRunner creates a new runsc runner. If runscPath is empty, it
+// attempts to find runsc in PATH.
+func NewRunner(runscPath, stateDir string) (*Runner, error) {
+	if runscPath == "" {
+		var err error
+		runscPath, err = exec.LookPath("runsc")
+		if err != nil {
+			return nil, fmt.Errorf("runsc not found in PATH: %w", err)
+		}
+	}
+
+	return &Runner{
+		RunscPath: runscPath,
+		StateDir:  stateDir,
+		Platform:  DefaultPlatform,
+	}, nil
+}
+
+// baseArgs returns the common arguments for all runsc commands.
+func (r *Runner) baseArgs() []string {
+	return []string{
+		"--root", r.StateDir,
+		"--platform=" + r.Platform,
+		"--directfs=true",
+		"--network=host",
+	}
+}
+
+// Run creates and starts a sandbox in detached mode. This is equivalent
+// to runsc create + runsc start in a single operation.
+//
+// The detached runsc process forks the sandbox and then exits. We send
+// stdout to /dev/null to prevent the forked sandbox from holding the
+// pipe open (which would cause CombinedOutput to block indefinitely).
+// Stderr is captured for error reporting.
+func (r *Runner) Run(ctx context.Context, id, bundleDir string) error {
+	args := r.baseArgs()
+	args = append(args, "run", "--detach", "--bundle", bundleDir, id)
+
+	if r.Debug {
+		log.Printf("sandbox: runsc %s", strings.Join(args, " "))
+	}
+
+	// Use a temporary file for stderr so we can capture error output
+	// without pipes. Pipes would be inherited by the detached sandbox
+	// child process, causing cmd.Wait() to block indefinitely.
+	stderrFile, err := os.CreateTemp("", "runsc-stderr-*")
+	if err != nil {
+		return fmt.Errorf("creating stderr temp file: %w", err)
+	}
+	defer os.Remove(stderrFile.Name())
+	defer stderrFile.Close()
+
+	devNull, err2 := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err2 != nil {
+		return fmt.Errorf("opening /dev/null: %w", err2)
+	}
+	defer devNull.Close()
+
+	cmd := exec.CommandContext(ctx, r.RunscPath, args...)
+	cmd.Stdout = devNull
+	cmd.Stderr = stderrFile
+
+	if err := cmd.Run(); err != nil {
+		// Read captured stderr for diagnostics.
+		var stderrOutput string
+		if _, seekErr := stderrFile.Seek(0, 0); seekErr == nil {
+			if data, readErr := os.ReadFile(stderrFile.Name()); readErr == nil {
+				stderrOutput = string(data)
+			}
+		}
+		return fmt.Errorf("runsc run %s: %w\nstderr: %s", id, err, stderrOutput)
+	}
+
+	return nil
+}
+
+// Kill sends a signal to the sandbox's init process.
+func (r *Runner) Kill(ctx context.Context, id, signal string) error {
+	args := r.baseArgs()
+	args = append(args, "kill", id, signal)
+
+	if r.Debug {
+		log.Printf("sandbox: runsc %s", strings.Join(args, " "))
+	}
+
+	cmd := exec.CommandContext(ctx, r.RunscPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("runsc kill %s %s: %w\noutput: %s", id, signal, err, string(output))
+	}
+
+	return nil
+}
+
+// Delete removes a sandbox. The sandbox must be stopped first.
+func (r *Runner) Delete(ctx context.Context, id string) error {
+	args := r.baseArgs()
+	args = append(args, "delete", id)
+
+	if r.Debug {
+		log.Printf("sandbox: runsc %s", strings.Join(args, " "))
+	}
+
+	cmd := exec.CommandContext(ctx, r.RunscPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("runsc delete %s: %w\noutput: %s", id, err, string(output))
+	}
+
+	return nil
+}
+
+// State queries the current state of a sandbox.
+func (r *Runner) State(ctx context.Context, id string) (*ContainerState, error) {
+	args := r.baseArgs()
+	args = append(args, "state", id)
+
+	cmd := exec.CommandContext(ctx, r.RunscPath, args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("runsc state %s: %w", id, err)
+	}
+
+	var state ContainerState
+	if err := json.Unmarshal(output, &state); err != nil {
+		return nil, fmt.Errorf("parsing runsc state output: %w", err)
+	}
+
+	return &state, nil
+}
+
+// IsRunning checks whether a sandbox is currently running.
+func (r *Runner) IsRunning(ctx context.Context, id string) (bool, error) {
+	state, err := r.State(ctx, id)
+	if err != nil {
+		// If the container doesn't exist, it's not running.
+		return false, nil
+	}
+	return state.Status == "running", nil
+}
+
+// Exec runs a command inside a running sandbox. This is used for admin
+// access (equivalent to tmux attach for native agents).
+func (r *Runner) Exec(ctx context.Context, id string, cmd []string) error {
+	args := r.baseArgs()
+	args = append(args, "exec", id)
+	args = append(args, cmd...)
+
+	if r.Debug {
+		log.Printf("sandbox: runsc %s", strings.Join(args, " "))
+	}
+
+	c := exec.CommandContext(ctx, r.RunscPath, args...)
+	output, err := c.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("runsc exec %s: %w\noutput: %s", id, err, string(output))
+	}
+
+	return nil
+}
+
+// Cleanup deletes any orphaned containers that may exist from a previous
+// agentd crash. This should be called on daemon startup.
+func (r *Runner) Cleanup(ctx context.Context) error {
+	args := r.baseArgs()
+	args = append(args, "list", "--format=json")
+
+	cmd := exec.CommandContext(ctx, r.RunscPath, args...)
+	output, err := cmd.Output()
+	if err != nil {
+		// If runsc list fails (e.g. no state dir yet), that's fine.
+		return nil
+	}
+
+	var containers []ContainerState
+	if err := json.Unmarshal(output, &containers); err != nil {
+		// Might be empty or malformed; not critical.
+		return nil
+	}
+
+	for _, c := range containers {
+		if c.Status == "stopped" || c.Status == "created" {
+			log.Printf("sandbox: cleaning up orphaned container %s (status=%s)", c.ID, c.Status)
+			_ = r.Delete(ctx, c.ID)
+		}
+	}
+
+	return nil
+}

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -1,0 +1,44 @@
+// Package sandbox implements gVisor-based agent sandboxing for agentd.
+//
+// Sandboxed agents run inside gVisor (runsc) containers with read-only
+// /nix/store bind mounts from the host and writable tmpfs overlays for
+// the agent's home directory and /tmp. This provides process-level
+// isolation while sharing the host's Nix closure for fast cold starts.
+//
+// The package provides:
+//   - OCI runtime spec generation (oci.go)
+//   - Minimal rootfs preparation with /nix/store symlinks (rootfs.go)
+//   - Nix store closure computation (closure.go)
+//   - A runsc binary wrapper for container lifecycle (runsc.go)
+//   - A Manager that orchestrates the full sandbox lifecycle (manager.go)
+package sandbox
+
+// Config holds the configuration for creating a sandbox.
+type Config struct {
+	// ID is the unique identifier for this sandbox (e.g. "agent-claude-code").
+	ID string
+
+	// Command is the executable to run inside the sandbox.
+	Command string
+
+	// Args are the command-line arguments for the process.
+	Args []string
+
+	// Env holds environment variables for the sandboxed process.
+	Env map[string]string
+
+	// Workdir is the working directory inside the sandbox.
+	Workdir string
+
+	// StorePaths is the list of /nix/store paths to bind-mount (read-only).
+	StorePaths []string
+
+	// MemoryLimit is the memory limit in bytes. 0 means no limit.
+	MemoryLimit int64
+
+	// PidLimit is the maximum number of PIDs in the sandbox. 0 means no limit.
+	PidLimit int64
+
+	// Hostname is the hostname inside the sandbox.
+	Hostname string
+}

--- a/pkg/sandbox/sandbox_test.go
+++ b/pkg/sandbox/sandbox_test.go
@@ -1,0 +1,425 @@
+package sandbox_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/agentd/pkg/config"
+	"github.com/papercomputeco/agentd/pkg/harness"
+	"github.com/papercomputeco/agentd/pkg/sandbox"
+)
+
+func TestSandbox(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Sandbox Suite")
+}
+
+var _ = Describe("OCI Spec Generation", func() {
+	It("should generate a valid spec for a basic config", func() {
+		cfg := &sandbox.Config{
+			ID:          "test-sandbox",
+			Command:     "/bin/bash",
+			Args:        []string{"-c", "echo hello"},
+			Env:         map[string]string{"FOO": "bar"},
+			Workdir:     "/home/agent/workspace",
+			StorePaths:  []string{"/nix/store/abc-bash-5.2", "/nix/store/def-coreutils-9.4"},
+			MemoryLimit: 2 * 1024 * 1024 * 1024,
+			PidLimit:    512,
+			Hostname:    "test-host",
+		}
+
+		spec, err := sandbox.GenerateSpec(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spec).NotTo(BeNil())
+
+		// Check process.
+		Expect(spec.Process.Args).To(Equal([]string{"/bin/bash", "-c", "echo hello"}))
+		Expect(spec.Process.User.UID).To(Equal(uint32(1000)))
+		Expect(spec.Process.User.GID).To(Equal(uint32(1000)))
+		Expect(spec.Process.Cwd).To(Equal("/home/agent/workspace"))
+		Expect(spec.Process.Terminal).To(BeFalse())
+
+		// Check environment includes standard vars and custom ones.
+		Expect(spec.Process.Env).To(ContainElement("HOME=/home/agent"))
+		Expect(spec.Process.Env).To(ContainElement("PATH=/bin:/usr/bin"))
+		Expect(spec.Process.Env).To(ContainElement("FOO=bar"))
+
+		// Check root.
+		Expect(spec.Root.Path).To(Equal("rootfs"))
+
+		// Check hostname.
+		Expect(spec.Hostname).To(Equal("test-host"))
+
+		// Check namespaces: should have pid, ipc, uts, mount but NOT network.
+		namespaceTypes := make([]string, 0, len(spec.Linux.Namespaces))
+		for _, ns := range spec.Linux.Namespaces {
+			namespaceTypes = append(namespaceTypes, string(ns.Type))
+		}
+		Expect(namespaceTypes).To(ContainElements("pid", "ipc", "uts", "mount"))
+		Expect(namespaceTypes).NotTo(ContainElement("network"))
+
+		// Check resource limits.
+		Expect(spec.Linux.Resources).NotTo(BeNil())
+		Expect(spec.Linux.Resources.Memory).NotTo(BeNil())
+		Expect(*spec.Linux.Resources.Memory.Limit).To(Equal(int64(2 * 1024 * 1024 * 1024)))
+		Expect(spec.Linux.Resources.Pids).NotTo(BeNil())
+		Expect(*spec.Linux.Resources.Pids.Limit).To(Equal(int64(512)))
+	})
+
+	It("should include standard mounts and nix store bind mounts", func() {
+		storePaths := []string{
+			"/nix/store/abc-bash-5.2",
+			"/nix/store/def-glibc-2.39",
+			"/nix/store/ghi-coreutils-9.4",
+		}
+		cfg := &sandbox.Config{
+			ID:         "mount-test",
+			Command:    "/bin/bash",
+			StorePaths: storePaths,
+		}
+
+		spec, err := sandbox.GenerateSpec(cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Count mount types.
+		var procCount, tmpfsCount, sysfsCount, bindCount int
+		for _, m := range spec.Mounts {
+			switch m.Type {
+			case "proc":
+				procCount++
+			case "tmpfs":
+				tmpfsCount++
+			case "sysfs":
+				sysfsCount++
+			case "bind":
+				bindCount++
+			}
+		}
+
+		// Standard mounts: /proc (1), /dev (tmpfs), /sys (sysfs), /tmp (tmpfs), /home/agent (tmpfs)
+		Expect(procCount).To(Equal(1))
+		Expect(tmpfsCount).To(Equal(3)) // /dev, /tmp, /home/agent
+		Expect(sysfsCount).To(Equal(1))
+		Expect(bindCount).To(Equal(len(storePaths)))
+
+		// Check each nix store mount is read-only.
+		for _, m := range spec.Mounts {
+			if m.Type == "bind" {
+				Expect(m.Options).To(ContainElement("ro"))
+				Expect(m.Options).To(ContainElement("rbind"))
+				Expect(m.Destination).To(HavePrefix("/nix/store/"))
+			}
+		}
+	})
+
+	It("should use defaults for empty workdir and hostname", func() {
+		cfg := &sandbox.Config{
+			ID:      "defaults-test",
+			Command: "/bin/bash",
+		}
+
+		spec, err := sandbox.GenerateSpec(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spec.Process.Cwd).To(Equal("/home/agent"))
+		Expect(spec.Hostname).To(Equal("defaults-test"))
+	})
+
+	It("should omit resource limits when zero", func() {
+		cfg := &sandbox.Config{
+			ID:          "no-limits",
+			Command:     "/bin/bash",
+			MemoryLimit: 0,
+			PidLimit:    0,
+		}
+
+		spec, err := sandbox.GenerateSpec(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spec.Linux.Resources).To(BeNil())
+	})
+
+	It("should reject empty ID", func() {
+		cfg := &sandbox.Config{Command: "/bin/bash"}
+		_, err := sandbox.GenerateSpec(cfg)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("ID is required"))
+	})
+
+	It("should reject empty command", func() {
+		cfg := &sandbox.Config{ID: "test"}
+		_, err := sandbox.GenerateSpec(cfg)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("command is required"))
+	})
+
+	It("should marshal spec to valid JSON", func() {
+		cfg := &sandbox.Config{
+			ID:      "json-test",
+			Command: "/bin/bash",
+		}
+		spec, err := sandbox.GenerateSpec(cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		data, err := sandbox.MarshalSpec(spec)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).NotTo(BeEmpty())
+		// Verify it's valid JSON by checking it starts with {
+		Expect(string(data)).To(HavePrefix("{"))
+	})
+})
+
+var _ = Describe("Rootfs Preparation", func() {
+	var rootfsDir string
+
+	BeforeEach(func() {
+		rootfsDir = GinkgoT().TempDir()
+	})
+
+	It("should create the standard directory skeleton", func() {
+		err := sandbox.PrepareRootfs(rootfsDir, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedDirs := []string{
+			"bin", "dev", "etc", "home/agent", "proc", "sys",
+			"tmp", "var", "run", "nix/store", "usr/bin",
+		}
+		for _, dir := range expectedDirs {
+			path := filepath.Join(rootfsDir, dir)
+			info, err := os.Stat(path)
+			Expect(err).NotTo(HaveOccurred(), "directory %s should exist", dir)
+			Expect(info.IsDir()).To(BeTrue(), "%s should be a directory", dir)
+		}
+	})
+
+	It("should write /etc/passwd with root and agent users", func() {
+		err := sandbox.PrepareRootfs(rootfsDir, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		data, err := os.ReadFile(filepath.Join(rootfsDir, "etc/passwd"))
+		Expect(err).NotTo(HaveOccurred())
+		content := string(data)
+		Expect(content).To(ContainSubstring("root:x:0:0"))
+		Expect(content).To(ContainSubstring("agent:x:1000:1000"))
+	})
+
+	It("should write /etc/group", func() {
+		err := sandbox.PrepareRootfs(rootfsDir, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		data, err := os.ReadFile(filepath.Join(rootfsDir, "etc/group"))
+		Expect(err).NotTo(HaveOccurred())
+		content := string(data)
+		Expect(content).To(ContainSubstring("root:x:0"))
+		Expect(content).To(ContainSubstring("agent:x:1000"))
+	})
+
+	It("should write /etc/hostname, hosts, and resolv.conf", func() {
+		err := sandbox.PrepareRootfs(rootfsDir, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		hostname, err := os.ReadFile(filepath.Join(rootfsDir, "etc/hostname"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(hostname)).To(ContainSubstring("sandbox"))
+
+		hosts, err := os.ReadFile(filepath.Join(rootfsDir, "etc/hosts"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(hosts)).To(ContainSubstring("127.0.0.1"))
+
+		resolv, err := os.ReadFile(filepath.Join(rootfsDir, "etc/resolv.conf"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(resolv)).To(ContainSubstring("nameserver"))
+	})
+
+	It("should symlink binaries from store paths", func() {
+		// Create a fake /nix/store path with a bin directory.
+		fakeStore := filepath.Join(GinkgoT().TempDir(), "nix/store/abc-test-1.0")
+		fakeBin := filepath.Join(fakeStore, "bin")
+		Expect(os.MkdirAll(fakeBin, 0755)).To(Succeed())
+
+		// Create a fake executable.
+		fakeExe := filepath.Join(fakeBin, "test-tool")
+		Expect(os.WriteFile(fakeExe, []byte("#!/bin/sh\necho test"), 0755)).To(Succeed())
+
+		err := sandbox.PrepareRootfs(rootfsDir, []string{fakeStore})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check that the symlink was created.
+		linkPath := filepath.Join(rootfsDir, "bin/test-tool")
+		info, err := os.Lstat(linkPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode()&os.ModeSymlink).NotTo(BeZero(), "should be a symlink")
+
+		// Verify the symlink target.
+		target, err := os.Readlink(linkPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(target).To(Equal(fakeExe))
+	})
+
+	It("should not symlink non-executable files", func() {
+		fakeStore := filepath.Join(GinkgoT().TempDir(), "nix/store/abc-test-1.0")
+		fakeBin := filepath.Join(fakeStore, "bin")
+		Expect(os.MkdirAll(fakeBin, 0755)).To(Succeed())
+
+		// Create a non-executable file.
+		Expect(os.WriteFile(filepath.Join(fakeBin, "readme.txt"), []byte("not executable"), 0644)).To(Succeed())
+
+		err := sandbox.PrepareRootfs(rootfsDir, []string{fakeStore})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = os.Lstat(filepath.Join(rootfsDir, "bin/readme.txt"))
+		Expect(os.IsNotExist(err)).To(BeTrue(), "non-executable should not be linked")
+	})
+})
+
+var _ = Describe("Closure", func() {
+	Describe("ComputeClosureFromManifest", func() {
+		It("should read store paths from a manifest file", func() {
+			dir := GinkgoT().TempDir()
+			manifest := filepath.Join(dir, "closure.txt")
+			content := `/nix/store/abc-bash-5.2
+/nix/store/def-glibc-2.39
+/nix/store/ghi-coreutils-9.4
+`
+			Expect(os.WriteFile(manifest, []byte(content), 0644)).To(Succeed())
+
+			paths, err := sandbox.ComputeClosureFromManifest(manifest)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(paths).To(HaveLen(3))
+			Expect(paths).To(ContainElements(
+				"/nix/store/abc-bash-5.2",
+				"/nix/store/def-glibc-2.39",
+				"/nix/store/ghi-coreutils-9.4",
+			))
+		})
+
+		It("should skip comments and empty lines", func() {
+			dir := GinkgoT().TempDir()
+			manifest := filepath.Join(dir, "closure.txt")
+			content := `# This is a comment
+
+/nix/store/abc-bash-5.2
+# Another comment
+/nix/store/def-glibc-2.39
+`
+			Expect(os.WriteFile(manifest, []byte(content), 0644)).To(Succeed())
+
+			paths, err := sandbox.ComputeClosureFromManifest(manifest)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(paths).To(HaveLen(2))
+		})
+
+		It("should skip non-nix-store paths", func() {
+			dir := GinkgoT().TempDir()
+			manifest := filepath.Join(dir, "closure.txt")
+			content := `/nix/store/abc-bash-5.2
+/usr/bin/something
+/nix/store/def-glibc-2.39
+`
+			Expect(os.WriteFile(manifest, []byte(content), 0644)).To(Succeed())
+
+			paths, err := sandbox.ComputeClosureFromManifest(manifest)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(paths).To(HaveLen(2))
+		})
+
+		It("should return error for non-existent file", func() {
+			_, err := sandbox.ComputeClosureFromManifest("/nonexistent/closure.txt")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("Runner", func() {
+	It("should fail to create runner when runsc is not available", func() {
+		_, err := sandbox.NewRunner("/nonexistent/runsc", "/tmp/state")
+		// NewRunner with an explicit path doesn't check existence,
+		// but an empty path with no runsc in PATH should fail.
+		Expect(err).To(BeNil()) // explicit path is accepted as-is
+	})
+
+	It("should detect runsc in PATH", func() {
+		_, lookErr := exec.LookPath("runsc")
+		if lookErr != nil {
+			Skip("runsc not available in PATH")
+		}
+
+		runner, err := sandbox.NewRunner("", "/tmp/state")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(runner).NotTo(BeNil())
+		Expect(runner.RunscPath).NotTo(BeEmpty())
+	})
+})
+
+var _ = Describe("Manager", func() {
+	It("should create a manager with valid options", func() {
+		runner, _ := sandbox.NewRunner("/usr/bin/runsc", "/tmp/state")
+		cfg := &config.AgentConfig{
+			Type:     config.AgentTypeSandboxed,
+			Harness:  "claude-code",
+			Workdir:  "/home/agent/workspace",
+			Restart:  config.RestartNo,
+			Memory:   "2GiB",
+			PidLimit: 512,
+		}
+		h, err := harness.Get("claude-code")
+		Expect(err).NotTo(HaveOccurred())
+
+		mgr := sandbox.NewManager(sandbox.ManagerOpts{
+			Config:  cfg,
+			Harness: h,
+			Runner:  runner,
+			Env:     map[string]string{"FOO": "bar"},
+			Prompt:  "fix the tests",
+		})
+
+		Expect(mgr).NotTo(BeNil())
+		Expect(mgr.IsRunning()).To(BeFalse())
+	})
+
+	It("should report correct initial status", func() {
+		runner, _ := sandbox.NewRunner("/usr/bin/runsc", "/tmp/state")
+		cfg := &config.AgentConfig{
+			Type:     config.AgentTypeSandboxed,
+			Harness:  "claude-code",
+			Workdir:  "/home/agent/workspace",
+			Restart:  config.RestartNo,
+			Memory:   "2GiB",
+			PidLimit: 512,
+		}
+		h, _ := harness.Get("claude-code")
+
+		mgr := sandbox.NewManager(sandbox.ManagerOpts{
+			Config:  cfg,
+			Harness: h,
+			Runner:  runner,
+		})
+
+		status := mgr.Status()
+		Expect(status.Name).To(Equal("claude-code"))
+		Expect(status.Running).To(BeFalse())
+		Expect(status.Restarts).To(Equal(0))
+		Expect(status.Error).To(BeEmpty())
+	})
+
+	It("should report zero restarts initially", func() {
+		runner, _ := sandbox.NewRunner("/usr/bin/runsc", "/tmp/state")
+		cfg := &config.AgentConfig{
+			Type:    config.AgentTypeSandboxed,
+			Harness: "opencode",
+			Restart: config.RestartNo,
+		}
+		h, _ := harness.Get("opencode")
+
+		mgr := sandbox.NewManager(sandbox.ManagerOpts{
+			Config:  cfg,
+			Harness: h,
+			Runner:  runner,
+		})
+
+		Expect(mgr.Restarts()).To(Equal(0))
+	})
+})

--- a/vendor/github.com/opencontainers/runtime-spec/LICENSE
+++ b/vendor/github.com/opencontainers/runtime-spec/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2015 The Linux Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -1,0 +1,1067 @@
+package specs
+
+import "os"
+
+// Spec is the base configuration for the container.
+type Spec struct {
+	// Version of the Open Container Initiative Runtime Specification with which the bundle complies.
+	Version string `json:"ociVersion"`
+	// Process configures the container process.
+	Process *Process `json:"process,omitempty"`
+	// Root configures the container's root filesystem.
+	Root *Root `json:"root,omitempty"`
+	// Hostname configures the container's hostname.
+	Hostname string `json:"hostname,omitempty"`
+	// Domainname configures the container's domainname.
+	Domainname string `json:"domainname,omitempty"`
+	// Mounts configures additional mounts (on top of Root).
+	Mounts []Mount `json:"mounts,omitempty"`
+	// Hooks configures callbacks for container lifecycle events.
+	Hooks *Hooks `json:"hooks,omitempty" platform:"linux,solaris,zos"`
+	// Annotations contains arbitrary metadata for the container.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Linux is platform-specific configuration for Linux based containers.
+	Linux *Linux `json:"linux,omitempty" platform:"linux"`
+	// Solaris is platform-specific configuration for Solaris based containers.
+	Solaris *Solaris `json:"solaris,omitempty" platform:"solaris"`
+	// Windows is platform-specific configuration for Windows based containers.
+	Windows *Windows `json:"windows,omitempty" platform:"windows"`
+	// VM specifies configuration for virtual-machine-based containers.
+	VM *VM `json:"vm,omitempty" platform:"vm"`
+	// ZOS is platform-specific configuration for z/OS based containers.
+	ZOS *ZOS `json:"zos,omitempty" platform:"zos"`
+	// FreeBSD is platform-specific configuration for FreeBSD based containers.
+	FreeBSD *FreeBSD `json:"freebsd,omitempty" platform:"freebsd"`
+}
+
+// Scheduler represents the scheduling attributes for a process. It is based on
+// the Linux sched_setattr(2) syscall.
+type Scheduler struct {
+	// Policy represents the scheduling policy (e.g., SCHED_FIFO, SCHED_RR, SCHED_OTHER).
+	Policy LinuxSchedulerPolicy `json:"policy"`
+
+	// Nice is the nice value for the process, which affects its priority.
+	Nice int32 `json:"nice,omitempty"`
+
+	// Priority represents the static priority of the process.
+	Priority int32 `json:"priority,omitempty"`
+
+	// Flags is an array of scheduling flags.
+	Flags []LinuxSchedulerFlag `json:"flags,omitempty"`
+
+	// The following ones are used by the DEADLINE scheduler.
+
+	// Runtime is the amount of time in nanoseconds during which the process
+	// is allowed to run in a given period.
+	Runtime uint64 `json:"runtime,omitempty"`
+
+	// Deadline is the absolute deadline for the process to complete its execution.
+	Deadline uint64 `json:"deadline,omitempty"`
+
+	// Period is the length of the period in nanoseconds used for determining the process runtime.
+	Period uint64 `json:"period,omitempty"`
+}
+
+// Process contains information to start a specific application inside the container.
+type Process struct {
+	// Terminal creates an interactive terminal for the container.
+	Terminal bool `json:"terminal,omitempty"`
+	// ConsoleSize specifies the size of the console.
+	ConsoleSize *Box `json:"consoleSize,omitempty"`
+	// User specifies user information for the process.
+	User User `json:"user"`
+	// Args specifies the binary and arguments for the application to execute.
+	Args []string `json:"args,omitempty"`
+	// CommandLine specifies the full command line for the application to execute on Windows.
+	CommandLine string `json:"commandLine,omitempty" platform:"windows"`
+	// Env populates the process environment for the process.
+	Env []string `json:"env,omitempty"`
+	// Cwd is the current working directory for the process and must be
+	// relative to the container's root.
+	Cwd string `json:"cwd"`
+	// Capabilities are Linux capabilities that are kept for the process.
+	Capabilities *LinuxCapabilities `json:"capabilities,omitempty" platform:"linux"`
+	// Rlimits specifies rlimit options to apply to the process.
+	Rlimits []POSIXRlimit `json:"rlimits,omitempty" platform:"linux,solaris,zos"`
+	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
+	NoNewPrivileges bool `json:"noNewPrivileges,omitempty" platform:"linux,zos"`
+	// ApparmorProfile specifies the apparmor profile for the container.
+	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
+	// Specify an oom_score_adj for the container.
+	OOMScoreAdj *int `json:"oomScoreAdj,omitempty" platform:"linux"`
+	// Scheduler specifies the scheduling attributes for a process
+	Scheduler *Scheduler `json:"scheduler,omitempty" platform:"linux"`
+	// SelinuxLabel specifies the selinux context that the container process is run as.
+	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
+	// IOPriority contains the I/O priority settings for the cgroup.
+	IOPriority *LinuxIOPriority `json:"ioPriority,omitempty" platform:"linux"`
+	// ExecCPUAffinity specifies CPU affinity for exec processes.
+	ExecCPUAffinity *CPUAffinity `json:"execCPUAffinity,omitempty" platform:"linux"`
+}
+
+// LinuxCapabilities specifies the list of allowed capabilities that are kept for a process.
+// https://man7.org/linux/man-pages/man7/capabilities.7.html
+type LinuxCapabilities struct {
+	// Bounding is the set of capabilities checked by the kernel.
+	Bounding []string `json:"bounding,omitempty" platform:"linux"`
+	// Effective is the set of capabilities checked by the kernel.
+	Effective []string `json:"effective,omitempty" platform:"linux"`
+	// Inheritable is the capabilities preserved across execve.
+	Inheritable []string `json:"inheritable,omitempty" platform:"linux"`
+	// Permitted is the limiting superset for effective capabilities.
+	Permitted []string `json:"permitted,omitempty" platform:"linux"`
+	// Ambient is the ambient set of capabilities that are kept.
+	Ambient []string `json:"ambient,omitempty" platform:"linux"`
+}
+
+// IOPriority represents I/O priority settings for the container's processes within the process group.
+type LinuxIOPriority struct {
+	Class    IOPriorityClass `json:"class"`
+	Priority int             `json:"priority"`
+}
+
+// IOPriorityClass represents an I/O scheduling class.
+type IOPriorityClass string
+
+// Possible values for IOPriorityClass.
+const (
+	IOPRIO_CLASS_RT   IOPriorityClass = "IOPRIO_CLASS_RT"
+	IOPRIO_CLASS_BE   IOPriorityClass = "IOPRIO_CLASS_BE"
+	IOPRIO_CLASS_IDLE IOPriorityClass = "IOPRIO_CLASS_IDLE"
+)
+
+// CPUAffinity specifies process' CPU affinity.
+type CPUAffinity struct {
+	Initial string `json:"initial,omitempty"`
+	Final   string `json:"final,omitempty"`
+}
+
+// Box specifies dimensions of a rectangle. Used for specifying the size of a console.
+type Box struct {
+	// Height is the vertical dimension of a box.
+	Height uint `json:"height"`
+	// Width is the horizontal dimension of a box.
+	Width uint `json:"width"`
+}
+
+// User specifies specific user (and group) information for the container process.
+type User struct {
+	// UID is the user id.
+	UID uint32 `json:"uid" platform:"linux,solaris,zos"`
+	// GID is the group id.
+	GID uint32 `json:"gid" platform:"linux,solaris,zos"`
+	// Umask is the umask for the init process.
+	Umask *uint32 `json:"umask,omitempty" platform:"linux,solaris,zos"`
+	// AdditionalGids are additional group ids set for the container's process.
+	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux,solaris"`
+	// Username is the user name.
+	Username string `json:"username,omitempty" platform:"windows"`
+}
+
+// Root contains information about the container's root filesystem on the host.
+type Root struct {
+	// Path is the absolute path to the container's root filesystem.
+	Path string `json:"path"`
+	// Readonly makes the root filesystem for the container readonly before the process is executed.
+	Readonly bool `json:"readonly,omitempty"`
+}
+
+// Mount specifies a mount for a container.
+type Mount struct {
+	// Destination is the absolute path where the mount will be placed in the container.
+	Destination string `json:"destination"`
+	// Type specifies the mount kind.
+	Type string `json:"type,omitempty" platform:"linux,solaris,zos,freebsd"`
+	// Source specifies the source path of the mount.
+	Source string `json:"source,omitempty"`
+	// Options are fstab style mount options.
+	Options []string `json:"options,omitempty"`
+
+	// UID/GID mappings used for changing file owners w/o calling chown, fs should support it.
+	// Every mount point could have its own mapping.
+	UIDMappings []LinuxIDMapping `json:"uidMappings,omitempty" platform:"linux"`
+	GIDMappings []LinuxIDMapping `json:"gidMappings,omitempty" platform:"linux"`
+}
+
+// Hook specifies a command that is run at a particular event in the lifecycle of a container
+type Hook struct {
+	Path    string   `json:"path"`
+	Args    []string `json:"args,omitempty"`
+	Env     []string `json:"env,omitempty"`
+	Timeout *int     `json:"timeout,omitempty"`
+}
+
+// Hooks specifies a command that is run in the container at a particular event in the lifecycle of a container
+// Hooks for container setup and teardown
+type Hooks struct {
+	// Prestart is Deprecated. Prestart is a list of hooks to be run before the container process is executed.
+	// It is called in the Runtime Namespace
+	//
+	// Deprecated: use [Hooks.CreateRuntime], [Hooks.CreateContainer], and
+	// [Hooks.StartContainer] instead, which allow more granular hook control
+	// during the create and start phase.
+	Prestart []Hook `json:"prestart,omitempty"`
+	// CreateRuntime is a list of hooks to be run after the container has been created but before pivot_root or any equivalent operation has been called
+	// It is called in the Runtime Namespace
+	CreateRuntime []Hook `json:"createRuntime,omitempty"`
+	// CreateContainer is a list of hooks to be run after the container has been created but before pivot_root or any equivalent operation has been called
+	// It is called in the Container Namespace
+	CreateContainer []Hook `json:"createContainer,omitempty"`
+	// StartContainer is a list of hooks to be run after the start operation is called but before the container process is started
+	// It is called in the Container Namespace
+	StartContainer []Hook `json:"startContainer,omitempty"`
+	// Poststart is a list of hooks to be run after the container process is started.
+	// It is called in the Runtime Namespace
+	Poststart []Hook `json:"poststart,omitempty"`
+	// Poststop is a list of hooks to be run after the container process exits.
+	// It is called in the Runtime Namespace
+	Poststop []Hook `json:"poststop,omitempty"`
+}
+
+// Linux contains platform-specific configuration for Linux based containers.
+type Linux struct {
+	// UIDMapping specifies user mappings for supporting user namespaces.
+	UIDMappings []LinuxIDMapping `json:"uidMappings,omitempty"`
+	// GIDMapping specifies group mappings for supporting user namespaces.
+	GIDMappings []LinuxIDMapping `json:"gidMappings,omitempty"`
+	// Sysctl are a set of key value pairs that are set for the container on start
+	Sysctl map[string]string `json:"sysctl,omitempty"`
+	// Resources contain cgroup information for handling resource constraints
+	// for the container
+	Resources *LinuxResources `json:"resources,omitempty"`
+	// CgroupsPath specifies the path to cgroups that are created and/or joined by the container.
+	// The path is expected to be relative to the cgroups mountpoint.
+	// If resources are specified, the cgroups at CgroupsPath will be updated based on resources.
+	CgroupsPath string `json:"cgroupsPath,omitempty"`
+	// Namespaces contains the namespaces that are created and/or joined by the container
+	Namespaces []LinuxNamespace `json:"namespaces,omitempty"`
+	// Devices are a list of device nodes that are created for the container
+	Devices []LinuxDevice `json:"devices,omitempty"`
+	// NetDevices are key-value pairs, keyed by network device name on the host, moved to the container's network namespace.
+	NetDevices map[string]LinuxNetDevice `json:"netDevices,omitempty"`
+	// Seccomp specifies the seccomp security settings for the container.
+	Seccomp *LinuxSeccomp `json:"seccomp,omitempty"`
+	// RootfsPropagation is the rootfs mount propagation mode for the container.
+	RootfsPropagation string `json:"rootfsPropagation,omitempty"`
+	// MaskedPaths masks over the provided paths inside the container.
+	MaskedPaths []string `json:"maskedPaths,omitempty"`
+	// ReadonlyPaths sets the provided paths as RO inside the container.
+	ReadonlyPaths []string `json:"readonlyPaths,omitempty"`
+	// MountLabel specifies the selinux context for the mounts in the container.
+	MountLabel string `json:"mountLabel,omitempty"`
+	// IntelRdt contains Intel Resource Director Technology (RDT) information for
+	// handling resource constraints and monitoring metrics (e.g., L3 cache, memory bandwidth) for the container
+	IntelRdt *LinuxIntelRdt `json:"intelRdt,omitempty"`
+	// MemoryPolicy contains NUMA memory policy for the container.
+	MemoryPolicy *LinuxMemoryPolicy `json:"memoryPolicy,omitempty"`
+	// Personality contains configuration for the Linux personality syscall
+	Personality *LinuxPersonality `json:"personality,omitempty"`
+	// TimeOffsets specifies the offset for supporting time namespaces.
+	TimeOffsets map[string]LinuxTimeOffset `json:"timeOffsets,omitempty"`
+}
+
+// LinuxNamespace is the configuration for a Linux namespace
+type LinuxNamespace struct {
+	// Type is the type of namespace
+	Type LinuxNamespaceType `json:"type"`
+	// Path is a path to an existing namespace persisted on disk that can be joined
+	// and is of the same type
+	Path string `json:"path,omitempty"`
+}
+
+// LinuxNamespaceType is one of the Linux namespaces
+type LinuxNamespaceType string
+
+const (
+	// PIDNamespace for isolating process IDs
+	PIDNamespace LinuxNamespaceType = "pid"
+	// NetworkNamespace for isolating network devices, stacks, ports, etc
+	NetworkNamespace LinuxNamespaceType = "network"
+	// MountNamespace for isolating mount points
+	MountNamespace LinuxNamespaceType = "mount"
+	// IPCNamespace for isolating System V IPC, POSIX message queues
+	IPCNamespace LinuxNamespaceType = "ipc"
+	// UTSNamespace for isolating hostname and NIS domain name
+	UTSNamespace LinuxNamespaceType = "uts"
+	// UserNamespace for isolating user and group IDs
+	UserNamespace LinuxNamespaceType = "user"
+	// CgroupNamespace for isolating cgroup hierarchies
+	CgroupNamespace LinuxNamespaceType = "cgroup"
+	// TimeNamespace for isolating the clocks
+	TimeNamespace LinuxNamespaceType = "time"
+)
+
+// LinuxIDMapping specifies UID/GID mappings
+type LinuxIDMapping struct {
+	// ContainerID is the starting UID/GID in the container
+	ContainerID uint32 `json:"containerID"`
+	// HostID is the starting UID/GID on the host to be mapped to 'ContainerID'
+	HostID uint32 `json:"hostID"`
+	// Size is the number of IDs to be mapped
+	Size uint32 `json:"size"`
+}
+
+// LinuxTimeOffset specifies the offset for Time Namespace
+type LinuxTimeOffset struct {
+	// Secs is the offset of clock (in secs) in the container
+	Secs int64 `json:"secs,omitempty"`
+	// Nanosecs is the additional offset for Secs (in nanosecs)
+	Nanosecs uint32 `json:"nanosecs,omitempty"`
+}
+
+// POSIXRlimit type and restrictions
+type POSIXRlimit struct {
+	// Type of the rlimit to set
+	Type string `json:"type"`
+	// Hard is the hard limit for the specified type
+	Hard uint64 `json:"hard"`
+	// Soft is the soft limit for the specified type
+	Soft uint64 `json:"soft"`
+}
+
+// LinuxHugepageLimit structure corresponds to limiting kernel hugepages.
+// Default to reservation limits if supported. Otherwise fallback to page fault limits.
+type LinuxHugepageLimit struct {
+	// Pagesize is the hugepage size.
+	// Format: "<size><unit-prefix>B' (e.g. 64KB, 2MB, 1GB, etc.).
+	Pagesize string `json:"pageSize"`
+	// Limit is the limit of "hugepagesize" hugetlb reservations (if supported) or usage.
+	Limit uint64 `json:"limit"`
+}
+
+// LinuxInterfacePriority for network interfaces
+type LinuxInterfacePriority struct {
+	// Name is the name of the network interface
+	Name string `json:"name"`
+	// Priority for the interface
+	Priority uint32 `json:"priority"`
+}
+
+// LinuxBlockIODevice holds major:minor format supported in blkio cgroup
+type LinuxBlockIODevice struct {
+	// Major is the device's major number.
+	Major int64 `json:"major"`
+	// Minor is the device's minor number.
+	Minor int64 `json:"minor"`
+}
+
+// LinuxWeightDevice struct holds a `major:minor weight` pair for weightDevice
+type LinuxWeightDevice struct {
+	LinuxBlockIODevice
+	// Weight is the bandwidth rate for the device.
+	Weight *uint16 `json:"weight,omitempty"`
+	// LeafWeight is the bandwidth rate for the device while competing with the cgroup's child cgroups, CFQ scheduler only
+	LeafWeight *uint16 `json:"leafWeight,omitempty"`
+}
+
+// LinuxThrottleDevice struct holds a `major:minor rate_per_second` pair
+type LinuxThrottleDevice struct {
+	LinuxBlockIODevice
+	// Rate is the IO rate limit per cgroup per device
+	Rate uint64 `json:"rate"`
+}
+
+// LinuxBlockIO for Linux cgroup 'blkio' resource management
+type LinuxBlockIO struct {
+	// Specifies per cgroup weight
+	Weight *uint16 `json:"weight,omitempty"`
+	// Specifies tasks' weight in the given cgroup while competing with the cgroup's child cgroups, CFQ scheduler only
+	LeafWeight *uint16 `json:"leafWeight,omitempty"`
+	// Weight per cgroup per device, can override BlkioWeight
+	WeightDevice []LinuxWeightDevice `json:"weightDevice,omitempty"`
+	// IO read rate limit per cgroup per device, bytes per second
+	ThrottleReadBpsDevice []LinuxThrottleDevice `json:"throttleReadBpsDevice,omitempty"`
+	// IO write rate limit per cgroup per device, bytes per second
+	ThrottleWriteBpsDevice []LinuxThrottleDevice `json:"throttleWriteBpsDevice,omitempty"`
+	// IO read rate limit per cgroup per device, IO per second
+	ThrottleReadIOPSDevice []LinuxThrottleDevice `json:"throttleReadIOPSDevice,omitempty"`
+	// IO write rate limit per cgroup per device, IO per second
+	ThrottleWriteIOPSDevice []LinuxThrottleDevice `json:"throttleWriteIOPSDevice,omitempty"`
+}
+
+// LinuxMemory for Linux cgroup 'memory' resource management
+type LinuxMemory struct {
+	// Memory limit (in bytes).
+	Limit *int64 `json:"limit,omitempty"`
+	// Memory reservation or soft_limit (in bytes).
+	Reservation *int64 `json:"reservation,omitempty"`
+	// Total memory limit (memory + swap).
+	Swap *int64 `json:"swap,omitempty"`
+	// Kernel memory limit (in bytes).
+	//
+	// Deprecated: kernel-memory limits are not supported in cgroups v2, and
+	// were obsoleted in [kernel v5.4]. This field should no longer be used,
+	// as it may be ignored by runtimes.
+	//
+	// [kernel v5.4]: https://github.com/torvalds/linux/commit/0158115f702b0ba208ab0
+	Kernel *int64 `json:"kernel,omitempty"`
+	// Kernel memory limit for tcp (in bytes)
+	KernelTCP *int64 `json:"kernelTCP,omitempty"`
+	// How aggressive the kernel will swap memory pages.
+	Swappiness *uint64 `json:"swappiness,omitempty"`
+	// DisableOOMKiller disables the OOM killer for out of memory conditions
+	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
+	// Enables hierarchical memory accounting
+	UseHierarchy *bool `json:"useHierarchy,omitempty"`
+	// CheckBeforeUpdate enables checking if a new memory limit is lower
+	// than the current usage during update, and if so, rejecting the new
+	// limit.
+	CheckBeforeUpdate *bool `json:"checkBeforeUpdate,omitempty"`
+}
+
+// LinuxCPU for Linux cgroup 'cpu' resource management
+type LinuxCPU struct {
+	// CPU shares (relative weight (ratio) vs. other cgroups with cpu shares).
+	Shares *uint64 `json:"shares,omitempty"`
+	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
+	Quota *int64 `json:"quota,omitempty"`
+	// CPU hardcap burst limit (in usecs). Allowed accumulated cpu time additionally for burst in a
+	// given period.
+	Burst *uint64 `json:"burst,omitempty"`
+	// CPU period to be used for hardcapping (in usecs).
+	Period *uint64 `json:"period,omitempty"`
+	// How much time realtime scheduling may use (in usecs).
+	RealtimeRuntime *int64 `json:"realtimeRuntime,omitempty"`
+	// CPU period to be used for realtime scheduling (in usecs).
+	RealtimePeriod *uint64 `json:"realtimePeriod,omitempty"`
+	// CPUs to use within the cpuset. Default is to use any CPU available.
+	Cpus string `json:"cpus,omitempty"`
+	// List of memory nodes in the cpuset. Default is to use any available memory node.
+	Mems string `json:"mems,omitempty"`
+	// cgroups are configured with minimum weight, 0: default behavior, 1: SCHED_IDLE.
+	Idle *int64 `json:"idle,omitempty"`
+}
+
+// LinuxPids for Linux cgroup 'pids' resource management (Linux 4.3)
+type LinuxPids struct {
+	// Maximum number of PIDs. Default is "no limit".
+	Limit *int64 `json:"limit,omitempty"`
+}
+
+// LinuxNetwork identification and priority configuration
+type LinuxNetwork struct {
+	// Set class identifier for container's network packets
+	ClassID *uint32 `json:"classID,omitempty"`
+	// Set priority of network traffic for container
+	Priorities []LinuxInterfacePriority `json:"priorities,omitempty"`
+}
+
+// LinuxRdma for Linux cgroup 'rdma' resource management (Linux 4.11)
+type LinuxRdma struct {
+	// Maximum number of HCA handles that can be opened. Default is "no limit".
+	HcaHandles *uint32 `json:"hcaHandles,omitempty"`
+	// Maximum number of HCA objects that can be created. Default is "no limit".
+	HcaObjects *uint32 `json:"hcaObjects,omitempty"`
+}
+
+// LinuxResources has container runtime resource constraints
+type LinuxResources struct {
+	// Devices configures the device allowlist.
+	Devices []LinuxDeviceCgroup `json:"devices,omitempty"`
+	// Memory restriction configuration
+	Memory *LinuxMemory `json:"memory,omitempty"`
+	// CPU resource restriction configuration
+	CPU *LinuxCPU `json:"cpu,omitempty"`
+	// Task resource restriction configuration.
+	Pids *LinuxPids `json:"pids,omitempty"`
+	// BlockIO restriction configuration
+	BlockIO *LinuxBlockIO `json:"blockIO,omitempty"`
+	// Hugetlb limits (in bytes). Default to reservation limits if supported.
+	HugepageLimits []LinuxHugepageLimit `json:"hugepageLimits,omitempty"`
+	// Network restriction configuration
+	Network *LinuxNetwork `json:"network,omitempty"`
+	// Rdma resource restriction configuration.
+	// Limits are a set of key value pairs that define RDMA resource limits,
+	// where the key is device name and value is resource limits.
+	Rdma map[string]LinuxRdma `json:"rdma,omitempty"`
+	// Unified resources.
+	Unified map[string]string `json:"unified,omitempty"`
+}
+
+// LinuxDevice represents the mknod information for a Linux special device file
+type LinuxDevice struct {
+	// Path to the device.
+	Path string `json:"path"`
+	// Device type, block, char, etc.
+	Type string `json:"type"`
+	// Major is the device's major number.
+	Major int64 `json:"major"`
+	// Minor is the device's minor number.
+	Minor int64 `json:"minor"`
+	// FileMode permission bits for the device.
+	FileMode *os.FileMode `json:"fileMode,omitempty"`
+	// UID of the device.
+	UID *uint32 `json:"uid,omitempty"`
+	// Gid of the device.
+	GID *uint32 `json:"gid,omitempty"`
+}
+
+// LinuxNetDevice represents a single network device to be added to the container's network namespace
+type LinuxNetDevice struct {
+	// Name of the device in the container namespace
+	Name string `json:"name,omitempty"`
+}
+
+// LinuxDeviceCgroup represents a device rule for the devices specified to
+// the device controller
+type LinuxDeviceCgroup struct {
+	// Allow or deny
+	Allow bool `json:"allow"`
+	// Device type, block, char, etc.
+	Type string `json:"type,omitempty"`
+	// Major is the device's major number.
+	Major *int64 `json:"major,omitempty"`
+	// Minor is the device's minor number.
+	Minor *int64 `json:"minor,omitempty"`
+	// Cgroup access permissions format, rwm.
+	Access string `json:"access,omitempty"`
+}
+
+// LinuxPersonalityDomain refers to a personality domain.
+type LinuxPersonalityDomain string
+
+// LinuxPersonalityFlag refers to an additional personality flag. None are currently defined.
+type LinuxPersonalityFlag string
+
+// Define domain and flags for Personality
+const (
+	// PerLinux is the standard Linux personality
+	PerLinux LinuxPersonalityDomain = "LINUX"
+	// PerLinux32 sets personality to 32 bit
+	PerLinux32 LinuxPersonalityDomain = "LINUX32"
+)
+
+// LinuxPersonality represents the Linux personality syscall input
+type LinuxPersonality struct {
+	// Domain for the personality
+	Domain LinuxPersonalityDomain `json:"domain"`
+	// Additional flags
+	Flags []LinuxPersonalityFlag `json:"flags,omitempty"`
+}
+
+// Solaris contains platform-specific configuration for Solaris application containers.
+type Solaris struct {
+	// SMF FMRI which should go "online" before we start the container process.
+	Milestone string `json:"milestone,omitempty"`
+	// Maximum set of privileges any process in this container can obtain.
+	LimitPriv string `json:"limitpriv,omitempty"`
+	// The maximum amount of shared memory allowed for this container.
+	MaxShmMemory string `json:"maxShmMemory,omitempty"`
+	// Specification for automatic creation of network resources for this container.
+	Anet []SolarisAnet `json:"anet,omitempty"`
+	// Set limit on the amount of CPU time that can be used by container.
+	CappedCPU *SolarisCappedCPU `json:"cappedCPU,omitempty"`
+	// The physical and swap caps on the memory that can be used by this container.
+	CappedMemory *SolarisCappedMemory `json:"cappedMemory,omitempty"`
+}
+
+// SolarisCappedCPU allows users to set limit on the amount of CPU time that can be used by container.
+type SolarisCappedCPU struct {
+	Ncpus string `json:"ncpus,omitempty"`
+}
+
+// SolarisCappedMemory allows users to set the physical and swap caps on the memory that can be used by this container.
+type SolarisCappedMemory struct {
+	Physical string `json:"physical,omitempty"`
+	Swap     string `json:"swap,omitempty"`
+}
+
+// SolarisAnet provides the specification for automatic creation of network resources for this container.
+type SolarisAnet struct {
+	// Specify a name for the automatically created VNIC datalink.
+	Linkname string `json:"linkname,omitempty"`
+	// Specify the link over which the VNIC will be created.
+	Lowerlink string `json:"lowerLink,omitempty"`
+	// The set of IP addresses that the container can use.
+	Allowedaddr string `json:"allowedAddress,omitempty"`
+	// Specifies whether allowedAddress limitation is to be applied to the VNIC.
+	Configallowedaddr string `json:"configureAllowedAddress,omitempty"`
+	// The value of the optional default router.
+	Defrouter string `json:"defrouter,omitempty"`
+	// Enable one or more types of link protection.
+	Linkprotection string `json:"linkProtection,omitempty"`
+	// Set the VNIC's macAddress
+	Macaddress string `json:"macAddress,omitempty"`
+}
+
+// Windows defines the runtime configuration for Windows based containers, including Hyper-V containers.
+type Windows struct {
+	// LayerFolders contains a list of absolute paths to directories containing image layers.
+	LayerFolders []string `json:"layerFolders"`
+	// Devices are the list of devices to be mapped into the container.
+	Devices []WindowsDevice `json:"devices,omitempty"`
+	// Resources contains information for handling resource constraints for the container.
+	Resources *WindowsResources `json:"resources,omitempty"`
+	// CredentialSpec contains a JSON object describing a group Managed Service Account (gMSA) specification.
+	CredentialSpec interface{} `json:"credentialSpec,omitempty"`
+	// Servicing indicates if the container is being started in a mode to apply a Windows Update servicing operation.
+	Servicing bool `json:"servicing,omitempty"`
+	// IgnoreFlushesDuringBoot indicates if the container is being started in a mode where disk writes are not flushed during its boot process.
+	IgnoreFlushesDuringBoot bool `json:"ignoreFlushesDuringBoot,omitempty"`
+	// HyperV contains information for running a container with Hyper-V isolation.
+	HyperV *WindowsHyperV `json:"hyperv,omitempty"`
+	// Network restriction configuration.
+	Network *WindowsNetwork `json:"network,omitempty"`
+}
+
+// WindowsDevice represents information about a host device to be mapped into the container.
+type WindowsDevice struct {
+	// Device identifier: interface class GUID, etc.
+	ID string `json:"id"`
+	// Device identifier type: "class", etc.
+	IDType string `json:"idType"`
+}
+
+// WindowsResources has container runtime resource constraints for containers running on Windows.
+type WindowsResources struct {
+	// Memory restriction configuration.
+	Memory *WindowsMemoryResources `json:"memory,omitempty"`
+	// CPU resource restriction configuration.
+	CPU *WindowsCPUResources `json:"cpu,omitempty"`
+	// Storage restriction configuration.
+	Storage *WindowsStorageResources `json:"storage,omitempty"`
+}
+
+// WindowsMemoryResources contains memory resource management settings.
+type WindowsMemoryResources struct {
+	// Memory limit in bytes.
+	Limit *uint64 `json:"limit,omitempty"`
+}
+
+// WindowsCPUResources contains CPU resource management settings.
+type WindowsCPUResources struct {
+	// Count is the number of CPUs available to the container. It represents the
+	// fraction of the configured processor `count` in a container in relation
+	// to the processors available in the host. The fraction ultimately
+	// determines the portion of processor cycles that the threads in a
+	// container can use during each scheduling interval, as the number of
+	// cycles per 10,000 cycles.
+	Count *uint64 `json:"count,omitempty"`
+	// Shares limits the share of processor time given to the container relative
+	// to other workloads on the processor. The processor `shares` (`weight` at
+	// the platform level) is a value between 0 and 10000.
+	Shares *uint16 `json:"shares,omitempty"`
+	// Maximum determines the portion of processor cycles that the threads in a
+	// container can use during each scheduling interval, as the number of
+	// cycles per 10,000 cycles. Set processor `maximum` to a percentage times
+	// 100.
+	Maximum *uint16 `json:"maximum,omitempty"`
+	// Set of CPUs to affinitize for this container.
+	Affinity []WindowsCPUGroupAffinity `json:"affinity,omitempty"`
+}
+
+// Similar to _GROUP_AFFINITY struct defined in
+// https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/miniport/ns-miniport-_group_affinity
+type WindowsCPUGroupAffinity struct {
+	// CPU mask relative to this CPU group.
+	Mask uint64 `json:"mask,omitempty"`
+	// Processor group the mask refers to, as returned by GetLogicalProcessorInformationEx.
+	Group uint32 `json:"group,omitempty"`
+}
+
+// WindowsStorageResources contains storage resource management settings.
+type WindowsStorageResources struct {
+	// Specifies maximum Iops for the system drive.
+	Iops *uint64 `json:"iops,omitempty"`
+	// Specifies maximum bytes per second for the system drive.
+	Bps *uint64 `json:"bps,omitempty"`
+	// Sandbox size specifies the minimum size of the system drive in bytes.
+	SandboxSize *uint64 `json:"sandboxSize,omitempty"`
+}
+
+// WindowsNetwork contains network settings for Windows containers.
+type WindowsNetwork struct {
+	// List of HNS endpoints that the container should connect to.
+	EndpointList []string `json:"endpointList,omitempty"`
+	// Specifies if unqualified DNS name resolution is allowed.
+	AllowUnqualifiedDNSQuery bool `json:"allowUnqualifiedDNSQuery,omitempty"`
+	// Comma separated list of DNS suffixes to use for name resolution.
+	DNSSearchList []string `json:"DNSSearchList,omitempty"`
+	// Name (ID) of the container that we will share with the network stack.
+	NetworkSharedContainerName string `json:"networkSharedContainerName,omitempty"`
+	// name (ID) of the network namespace that will be used for the container.
+	NetworkNamespace string `json:"networkNamespace,omitempty"`
+}
+
+// WindowsHyperV contains information for configuring a container to run with Hyper-V isolation.
+type WindowsHyperV struct {
+	// UtilityVMPath is an optional path to the image used for the Utility VM.
+	UtilityVMPath string `json:"utilityVMPath,omitempty"`
+}
+
+// IOMems contains information about iomem addresses that should be passed to the VM.
+type IOMems struct {
+	// Guest Frame Number to map the iomem range. If GFN is not specified, the mapping will be done to the same Frame Number as was provided in FirstMFN.
+	FirstGFN *uint64 `json:"firstGFN,omitempty"`
+	// Physical page number of iomem regions.
+	FirstMFN *uint64 `json:"firstMFN"`
+	// Number of pages to be mapped.
+	NrMFNs *uint64 `json:"nrMFNs"`
+}
+
+// Hardware configuration for the VM image
+type HWConfig struct {
+	// Path to the container device-tree file that should be passed to the VM configuration.
+	DeviceTree string `json:"deviceTree,omitempty"`
+	// Number of virtual cpus for the VM.
+	VCPUs *uint32 `json:"vcpus,omitempty"`
+	// Maximum memory in bytes allocated to the VM.
+	Memory *uint64 `json:"memory,omitempty"`
+	// Host device tree nodes to passthrough to the VM.
+	DtDevs []string `json:"dtdevs,omitempty"`
+	// Allow auto-translated domains to access specific hardware I/O memory pages.
+	IOMems []IOMems `json:"iomems,omitempty"`
+	// Allows VM to access specific physical IRQs.
+	Irqs []uint32 `json:"irqs,omitempty"`
+}
+
+// VM contains information for virtual-machine-based containers.
+type VM struct {
+	// Hypervisor specifies hypervisor-related configuration for virtual-machine-based containers.
+	Hypervisor VMHypervisor `json:"hypervisor,omitempty"`
+	// Kernel specifies kernel-related configuration for virtual-machine-based containers.
+	Kernel VMKernel `json:"kernel"`
+	// Image specifies guest image related configuration for virtual-machine-based containers.
+	Image VMImage `json:"image,omitempty"`
+	// Hardware configuration that should be passed to the VM.
+	HwConfig *HWConfig `json:"hwconfig,omitempty"`
+}
+
+// VMHypervisor contains information about the hypervisor to use for a virtual machine.
+type VMHypervisor struct {
+	// Path is the host path to the hypervisor used to manage the virtual machine.
+	Path string `json:"path"`
+	// Parameters specifies parameters to pass to the hypervisor.
+	Parameters []string `json:"parameters,omitempty"`
+}
+
+// VMKernel contains information about the kernel to use for a virtual machine.
+type VMKernel struct {
+	// Path is the host path to the kernel used to boot the virtual machine.
+	Path string `json:"path"`
+	// Parameters specifies parameters to pass to the kernel.
+	Parameters []string `json:"parameters,omitempty"`
+	// InitRD is the host path to an initial ramdisk to be used by the kernel.
+	InitRD string `json:"initrd,omitempty"`
+}
+
+// VMImage contains information about the virtual machine root image.
+type VMImage struct {
+	// Path is the host path to the root image that the VM kernel would boot into.
+	Path string `json:"path"`
+	// Format is the root image format type (e.g. "qcow2", "raw", "vhd", etc).
+	Format string `json:"format"`
+}
+
+// LinuxSeccomp represents syscall restrictions
+type LinuxSeccomp struct {
+	DefaultAction    LinuxSeccompAction `json:"defaultAction"`
+	DefaultErrnoRet  *uint              `json:"defaultErrnoRet,omitempty"`
+	Architectures    []Arch             `json:"architectures,omitempty"`
+	Flags            []LinuxSeccompFlag `json:"flags,omitempty"`
+	ListenerPath     string             `json:"listenerPath,omitempty"`
+	ListenerMetadata string             `json:"listenerMetadata,omitempty"`
+	Syscalls         []LinuxSyscall     `json:"syscalls,omitempty"`
+}
+
+// Arch used for additional architectures
+type Arch string
+
+// LinuxSeccompFlag is a flag to pass to seccomp(2).
+type LinuxSeccompFlag string
+
+const (
+	// LinuxSeccompFlagLog is a seccomp flag to request all returned
+	// actions except SECCOMP_RET_ALLOW to be logged. An administrator may
+	// override this filter flag by preventing specific actions from being
+	// logged via the /proc/sys/kernel/seccomp/actions_logged file. (since
+	// Linux 4.14)
+	LinuxSeccompFlagLog LinuxSeccompFlag = "SECCOMP_FILTER_FLAG_LOG"
+
+	// LinuxSeccompFlagSpecAllow can be used to disable Speculative Store
+	// Bypass mitigation. (since Linux 4.17)
+	LinuxSeccompFlagSpecAllow LinuxSeccompFlag = "SECCOMP_FILTER_FLAG_SPEC_ALLOW"
+
+	// LinuxSeccompFlagWaitKillableRecv can be used to switch to the wait
+	// killable semantics. (since Linux 5.19)
+	LinuxSeccompFlagWaitKillableRecv LinuxSeccompFlag = "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV"
+)
+
+// Additional architectures permitted to be used for system calls
+// By default only the native architecture of the kernel is permitted
+const (
+	ArchX86         Arch = "SCMP_ARCH_X86"
+	ArchX86_64      Arch = "SCMP_ARCH_X86_64"
+	ArchX32         Arch = "SCMP_ARCH_X32"
+	ArchARM         Arch = "SCMP_ARCH_ARM"
+	ArchAARCH64     Arch = "SCMP_ARCH_AARCH64"
+	ArchMIPS        Arch = "SCMP_ARCH_MIPS"
+	ArchMIPS64      Arch = "SCMP_ARCH_MIPS64"
+	ArchMIPS64N32   Arch = "SCMP_ARCH_MIPS64N32"
+	ArchMIPSEL      Arch = "SCMP_ARCH_MIPSEL"
+	ArchMIPSEL64    Arch = "SCMP_ARCH_MIPSEL64"
+	ArchMIPSEL64N32 Arch = "SCMP_ARCH_MIPSEL64N32"
+	ArchPPC         Arch = "SCMP_ARCH_PPC"
+	ArchPPC64       Arch = "SCMP_ARCH_PPC64"
+	ArchPPC64LE     Arch = "SCMP_ARCH_PPC64LE"
+	ArchS390        Arch = "SCMP_ARCH_S390"
+	ArchS390X       Arch = "SCMP_ARCH_S390X"
+	ArchPARISC      Arch = "SCMP_ARCH_PARISC"
+	ArchPARISC64    Arch = "SCMP_ARCH_PARISC64"
+	ArchRISCV64     Arch = "SCMP_ARCH_RISCV64"
+	ArchLOONGARCH64 Arch = "SCMP_ARCH_LOONGARCH64"
+	ArchM68K        Arch = "SCMP_ARCH_M68K"
+	ArchSH          Arch = "SCMP_ARCH_SH"
+	ArchSHEB        Arch = "SCMP_ARCH_SHEB"
+)
+
+// LinuxSeccompAction taken upon Seccomp rule match
+type LinuxSeccompAction string
+
+// Define actions for Seccomp rules
+const (
+	ActKill        LinuxSeccompAction = "SCMP_ACT_KILL"
+	ActKillProcess LinuxSeccompAction = "SCMP_ACT_KILL_PROCESS"
+	ActKillThread  LinuxSeccompAction = "SCMP_ACT_KILL_THREAD"
+	ActTrap        LinuxSeccompAction = "SCMP_ACT_TRAP"
+	ActErrno       LinuxSeccompAction = "SCMP_ACT_ERRNO"
+	ActTrace       LinuxSeccompAction = "SCMP_ACT_TRACE"
+	ActAllow       LinuxSeccompAction = "SCMP_ACT_ALLOW"
+	ActLog         LinuxSeccompAction = "SCMP_ACT_LOG"
+	ActNotify      LinuxSeccompAction = "SCMP_ACT_NOTIFY"
+)
+
+// LinuxSeccompOperator used to match syscall arguments in Seccomp
+type LinuxSeccompOperator string
+
+// Define operators for syscall arguments in Seccomp
+const (
+	OpNotEqual     LinuxSeccompOperator = "SCMP_CMP_NE"
+	OpLessThan     LinuxSeccompOperator = "SCMP_CMP_LT"
+	OpLessEqual    LinuxSeccompOperator = "SCMP_CMP_LE"
+	OpEqualTo      LinuxSeccompOperator = "SCMP_CMP_EQ"
+	OpGreaterEqual LinuxSeccompOperator = "SCMP_CMP_GE"
+	OpGreaterThan  LinuxSeccompOperator = "SCMP_CMP_GT"
+	OpMaskedEqual  LinuxSeccompOperator = "SCMP_CMP_MASKED_EQ"
+)
+
+// LinuxSeccompArg used for matching specific syscall arguments in Seccomp
+type LinuxSeccompArg struct {
+	Index    uint                 `json:"index"`
+	Value    uint64               `json:"value"`
+	ValueTwo uint64               `json:"valueTwo,omitempty"`
+	Op       LinuxSeccompOperator `json:"op"`
+}
+
+// LinuxSyscall is used to match a syscall in Seccomp
+type LinuxSyscall struct {
+	Names    []string           `json:"names"`
+	Action   LinuxSeccompAction `json:"action"`
+	ErrnoRet *uint              `json:"errnoRet,omitempty"`
+	Args     []LinuxSeccompArg  `json:"args,omitempty"`
+}
+
+// LinuxIntelRdt has container runtime resource constraints for Intel RDT CAT and MBA
+// features and flags enabling Intel RDT CMT and MBM features.
+// Intel RDT features are available in Linux 4.14 and newer kernel versions.
+type LinuxIntelRdt struct {
+	// The identity for RDT Class of Service
+	ClosID string `json:"closID,omitempty"`
+
+	// Schemata specifies the complete schemata to be written as is to the
+	// schemata file in resctrl fs. Each element represents a single line in the schemata file.
+	// NOTE: This will overwrite schemas specified in the L3CacheSchema and/or
+	// MemBwSchema fields.
+	Schemata []string `json:"schemata,omitempty"`
+
+	// The schema for L3 cache id and capacity bitmask (CBM)
+	// Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
+	// NOTE: Should not be specified if Schemata is non-empty.
+	L3CacheSchema string `json:"l3CacheSchema,omitempty"`
+
+	// The schema of memory bandwidth per L3 cache id
+	// Format: "MB:<cache_id0>=bandwidth0;<cache_id1>=bandwidth1;..."
+	// The unit of memory bandwidth is specified in "percentages" by
+	// default, and in "MBps" if MBA Software Controller is enabled.
+	// NOTE: Should not be specified if Schemata is non-empty.
+	MemBwSchema string `json:"memBwSchema,omitempty"`
+
+	// EnableMonitoring enables resctrl monitoring for the container. This will
+	// create a dedicated resctrl monitoring group for the container.
+	EnableMonitoring bool `json:"enableMonitoring,omitempty"`
+}
+
+// LinuxMemoryPolicy represents input for the set_mempolicy syscall.
+type LinuxMemoryPolicy struct {
+	// Mode for the set_mempolicy syscall.
+	Mode MemoryPolicyModeType `json:"mode"`
+
+	// Nodes representing the nodemask for the set_mempolicy syscall in comma separated ranges format.
+	// Format: "<node0>-<node1>,<node2>,<node3>-<node4>,..."
+	Nodes string `json:"nodes"`
+
+	// Flags for the set_mempolicy syscall.
+	Flags []MemoryPolicyFlagType `json:"flags,omitempty"`
+}
+
+// ZOS contains platform-specific configuration for z/OS based containers.
+type ZOS struct {
+	// Namespaces contains the namespaces that are created and/or joined by the container
+	Namespaces []ZOSNamespace `json:"namespaces,omitempty"`
+}
+
+// ZOSNamespace is the configuration for a z/OS namespace
+type ZOSNamespace struct {
+	// Type is the type of namespace
+	Type ZOSNamespaceType `json:"type"`
+	// Path is a path to an existing namespace persisted on disk that can be joined
+	// and is of the same type
+	Path string `json:"path,omitempty"`
+}
+
+// ZOSNamespaceType is one of the z/OS namespaces
+type ZOSNamespaceType string
+
+const (
+	// PIDNamespace for isolating process IDs
+	ZOSPIDNamespace ZOSNamespaceType = "pid"
+	// MountNamespace for isolating mount points
+	ZOSMountNamespace ZOSNamespaceType = "mount"
+	// IPCNamespace for isolating System V IPC, POSIX message queues
+	ZOSIPCNamespace ZOSNamespaceType = "ipc"
+	// UTSNamespace for isolating hostname and NIS domain name
+	ZOSUTSNamespace ZOSNamespaceType = "uts"
+)
+
+type MemoryPolicyModeType string
+
+const (
+	MpolDefault            MemoryPolicyModeType = "MPOL_DEFAULT"
+	MpolBind               MemoryPolicyModeType = "MPOL_BIND"
+	MpolInterleave         MemoryPolicyModeType = "MPOL_INTERLEAVE"
+	MpolWeightedInterleave MemoryPolicyModeType = "MPOL_WEIGHTED_INTERLEAVE"
+	MpolPreferred          MemoryPolicyModeType = "MPOL_PREFERRED"
+	MpolPreferredMany      MemoryPolicyModeType = "MPOL_PREFERRED_MANY"
+	MpolLocal              MemoryPolicyModeType = "MPOL_LOCAL"
+)
+
+type MemoryPolicyFlagType string
+
+const (
+	MpolFNumaBalancing MemoryPolicyFlagType = "MPOL_F_NUMA_BALANCING"
+	MpolFRelativeNodes MemoryPolicyFlagType = "MPOL_F_RELATIVE_NODES"
+	MpolFStaticNodes   MemoryPolicyFlagType = "MPOL_F_STATIC_NODES"
+)
+
+// LinuxSchedulerPolicy represents different scheduling policies used with the Linux Scheduler
+type LinuxSchedulerPolicy string
+
+const (
+	// SchedOther is the default scheduling policy
+	SchedOther LinuxSchedulerPolicy = "SCHED_OTHER"
+	// SchedFIFO is the First-In-First-Out scheduling policy
+	SchedFIFO LinuxSchedulerPolicy = "SCHED_FIFO"
+	// SchedRR is the Round-Robin scheduling policy
+	SchedRR LinuxSchedulerPolicy = "SCHED_RR"
+	// SchedBatch is the Batch scheduling policy
+	SchedBatch LinuxSchedulerPolicy = "SCHED_BATCH"
+	// SchedISO is the Isolation scheduling policy
+	SchedISO LinuxSchedulerPolicy = "SCHED_ISO"
+	// SchedIdle is the Idle scheduling policy
+	SchedIdle LinuxSchedulerPolicy = "SCHED_IDLE"
+	// SchedDeadline is the Deadline scheduling policy
+	SchedDeadline LinuxSchedulerPolicy = "SCHED_DEADLINE"
+)
+
+// LinuxSchedulerFlag represents the flags used by the Linux Scheduler.
+type LinuxSchedulerFlag string
+
+const (
+	// SchedFlagResetOnFork represents the reset on fork scheduling flag
+	SchedFlagResetOnFork LinuxSchedulerFlag = "SCHED_FLAG_RESET_ON_FORK"
+	// SchedFlagReclaim represents the reclaim scheduling flag
+	SchedFlagReclaim LinuxSchedulerFlag = "SCHED_FLAG_RECLAIM"
+	// SchedFlagDLOverrun represents the deadline overrun scheduling flag
+	SchedFlagDLOverrun LinuxSchedulerFlag = "SCHED_FLAG_DL_OVERRUN"
+	// SchedFlagKeepPolicy represents the keep policy scheduling flag
+	SchedFlagKeepPolicy LinuxSchedulerFlag = "SCHED_FLAG_KEEP_POLICY"
+	// SchedFlagKeepParams represents the keep parameters scheduling flag
+	SchedFlagKeepParams LinuxSchedulerFlag = "SCHED_FLAG_KEEP_PARAMS"
+	// SchedFlagUtilClampMin represents the utilization clamp minimum scheduling flag
+	SchedFlagUtilClampMin LinuxSchedulerFlag = "SCHED_FLAG_UTIL_CLAMP_MIN"
+	// SchedFlagUtilClampMin represents the utilization clamp maximum scheduling flag
+	SchedFlagUtilClampMax LinuxSchedulerFlag = "SCHED_FLAG_UTIL_CLAMP_MAX"
+)
+
+// FreeBSD contains platform-specific configuration for FreeBSD based containers.
+type FreeBSD struct {
+	// Devices which are accessible in the container
+	Devices []FreeBSDDevice `json:"devices,omitempty"`
+	// Jail definition for this container
+	Jail *FreeBSDJail `json:"jail,omitempty"`
+}
+
+type FreeBSDDevice struct {
+	// Path to the device, relative to /dev.
+	Path string `json:"path"`
+	// FileMode permission bits for the device.
+	Mode *os.FileMode `json:"mode,omitempty"`
+}
+
+// FreeBSDJail describes how to configure the container's jail
+type FreeBSDJail struct {
+	// Parent jail name - this can be used to share a single vnet
+	// across several containers
+	Parent string `json:"parent,omitempty"`
+	// Whether to use parent UTS names or override in the container
+	Host FreeBSDSharing `json:"host,omitempty"`
+	// IPv4 address sharing for the container
+	Ip4 FreeBSDSharing `json:"ip4,omitempty"`
+	// IPv4 addresses for the container
+	Ip4Addr []string `json:"ip4Addr,omitempty"`
+	// IPv6 address sharing for the container
+	Ip6 FreeBSDSharing `json:"ip6,omitempty"`
+	// IPv6 addresses for the container
+	Ip6Addr []string `json:"ip6Addr,omitempty"`
+	// Which network stack to use for the container
+	Vnet FreeBSDSharing `json:"vnet,omitempty"`
+	// If set, Ip4Addr and Ip6Addr addresses will be added to this interface
+	Interface string `json:"interface,omitempty"`
+	// List interfaces to be moved to the container's vnet
+	VnetInterfaces []string `json:"vnetInterfaces,omitempty"`
+	// SystemV IPC message sharing for the container
+	SysVMsg FreeBSDSharing `json:"sysvmsg,omitempty"`
+	// SystemV semaphore message sharing for the container
+	SysVSem FreeBSDSharing `json:"sysvsem,omitempty"`
+	// SystemV memory sharing for the container
+	SysVShm FreeBSDSharing `json:"sysvshm,omitempty"`
+	// Mount visibility (see jail(8) for details)
+	EnforceStatfs *int `json:"enforceStatfs,omitempty"`
+	// Jail capabilities
+	Allow *FreeBSDJailAllow `json:"allow,omitempty"`
+}
+
+// These values are used to control access to features in the container, either
+// disabling the feature, sharing state with the parent or creating new private
+// state in the container.
+type FreeBSDSharing string
+
+const (
+	FreeBSDShareDisable FreeBSDSharing = "disable"
+	FreeBSDShareNew     FreeBSDSharing = "new"
+	FreeBSDShareInherit FreeBSDSharing = "inherit"
+)
+
+// FreeBSDJailAllow describes jail capabilities
+type FreeBSDJailAllow struct {
+	SetHostname   bool     `json:"setHostname,omitempty"`
+	RawSockets    bool     `json:"rawSockets,omitempty"`
+	Chflags       bool     `json:"chflags,omitempty"`
+	Mount         []string `json:"mount,omitempty"`
+	Quotas        bool     `json:"quotas,omitempty"`
+	SocketAf      bool     `json:"socketAf,omitempty"`
+	Mlock         bool     `json:"mlock,omitempty"`
+	ReservedPorts bool     `json:"reservedPorts,omitempty"`
+	Suser         bool     `json:"suser,omitempty"`
+}

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
@@ -1,0 +1,56 @@
+package specs
+
+// ContainerState represents the state of a container.
+type ContainerState string
+
+const (
+	// StateCreating indicates that the container is being created
+	StateCreating ContainerState = "creating"
+
+	// StateCreated indicates that the runtime has finished the create operation
+	StateCreated ContainerState = "created"
+
+	// StateRunning indicates that the container process has executed the
+	// user-specified program but has not exited
+	StateRunning ContainerState = "running"
+
+	// StateStopped indicates that the container process has exited
+	StateStopped ContainerState = "stopped"
+)
+
+// State holds information about the runtime state of the container.
+type State struct {
+	// Version is the version of the specification that is supported.
+	Version string `json:"ociVersion"`
+	// ID is the container ID
+	ID string `json:"id"`
+	// Status is the runtime status of the container.
+	Status ContainerState `json:"status"`
+	// Pid is the process ID for the container process.
+	Pid int `json:"pid,omitempty"`
+	// Bundle is the path to the container's bundle directory.
+	Bundle string `json:"bundle"`
+	// Annotations are key values associated with the container.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+const (
+	// SeccompFdName is the name of the seccomp notify file descriptor.
+	SeccompFdName string = "seccompFd"
+)
+
+// ContainerProcessState holds information about the state of a container process.
+type ContainerProcessState struct {
+	// Version is the version of the specification that is supported.
+	Version string `json:"ociVersion"`
+	// Fds is a string array containing the names of the file descriptors passed.
+	// The index of the name in this array corresponds to index of the file
+	// descriptor in the `SCM_RIGHTS` array.
+	Fds []string `json:"fds"`
+	// Pid is the process ID as seen by the runtime.
+	Pid int `json:"pid"`
+	// Opaque metadata.
+	Metadata string `json:"metadata,omitempty"`
+	// State of the container.
+	State State `json:"state"`
+}

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -1,0 +1,18 @@
+package specs
+
+import "fmt"
+
+const (
+	// VersionMajor is for an API incompatible changes
+	VersionMajor = 1
+	// VersionMinor is for functionality in a backwards-compatible manner
+	VersionMinor = 3
+	// VersionPatch is for backwards-compatible bug fixes
+	VersionPatch = 0
+
+	// VersionDev indicates development branch. Releases will be empty string.
+	VersionDev = ""
+)
+
+// Version is the specification version that the package types support.
+var Version = fmt.Sprintf("%d.%d.%d%s", VersionMajor, VersionMinor, VersionPatch, VersionDev)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -59,6 +59,9 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
+# github.com/opencontainers/runtime-spec v1.3.0
+## explicit
+github.com/opencontainers/runtime-spec/specs-go
 # go.yaml.in/yaml/v3 v3.0.4
 ## explicit; go 1.16
 go.yaml.in/yaml/v3


### PR DESCRIPTION
* ✨ enables `native` or `sandboxed` agent modes in `jcard.toml` `[agent]` key.
* ✨ `pkg/sandbox/` implements `runsc` sandbox manager for `sandboxed` mode, reading/generating nix store closures for mounted sandbox packages to a gvisor application kernel.
  * gVisor sandboxes are implemented using hand rolled `github.com/opencontainers/runtime-spec` OCI specs with the necessary `/nix/store` packages mounted to the sandbox.
  * This also supports the new `extra_packages` that can be set for packages in a gvisor sandbox: this runs `nix build` internally to go and build / get the package for use in the sandbox. It then adds that materialized package to the OCI 
