### PR TITLE
✨ feat: Add capabilities to spin up multiple agents and replicas

### DIFF
--- a/agentd/agentd.go
+++ b/agentd/agentd.go
@@ -2,8 +2,9 @@
 // supervising, and stopping configured agent harnesses (Claude Code,
 // OpenCode, Gemini CLI, etc.).
 //
-// agentd manages tmux sessions for each agent, allowing the admin user
-// to "tmux attach [session]" to introspect running agents.
+// agentd manages tmux sessions and gVisor sandboxes for multiple agents
+// concurrently, allowing the admin user to "tmux attach [session]" to
+// introspect running agents.
 //
 // The daemon uses a reconciliation-loop architecture inspired by
 // Kubernetes: it periodically reads the desired state from the
@@ -12,6 +13,9 @@
 // reconfiguring agents as needed). This design decouples agentd from
 // any control-plane daemon — external consumers pull agent state from
 // agentd's own HTTP API served over a Unix domain socket.
+//
+// To handle thousands of agents efficiently, agent launches are
+// throttled through a worker pool with a configurable concurrency limit.
 package agentd
 
 import (
@@ -63,6 +67,11 @@ const (
 
 	// DefaultSandboxBundleDir is the default base directory for OCI bundles.
 	DefaultSandboxBundleDir = "/run/agentd/sandboxes"
+
+	// DefaultLaunchConcurrency is the maximum number of agents that can
+	// be launched concurrently. This prevents resource exhaustion when
+	// bringing hundreds of agents online simultaneously.
+	DefaultLaunchConcurrency = 50
 )
 
 // AgentManager is the common interface for agent lifecycle management.
@@ -75,6 +84,13 @@ type AgentManager interface {
 	Status() api.AgentStatus
 }
 
+// managedAgent tracks a running agent along with the config hash that
+// was used to start it, enabling per-agent change detection.
+type managedAgent struct {
+	manager    AgentManager
+	configHash [sha256.Size]byte
+}
+
 // Daemon is the agent daemon. It runs a reconciliation loop that
 // watches for configuration and secret changes, serves an API for
 // external consumers to pull agent state, and manages agent harnesses
@@ -85,6 +101,7 @@ type Daemon struct {
 	apiSocketPath     string
 	tmuxSocketPath    string
 	reconcileInterval time.Duration
+	launchConcurrency int
 	debug             bool
 
 	// Sandbox configuration.
@@ -94,14 +111,12 @@ type Daemon struct {
 
 	// runtime state, guarded by mu
 	mu        sync.Mutex
-	manager   AgentManager
+	agents    map[string]*managedAgent // keyed by agent name
 	tmux      *tmux.Server
 	runner    *sandbox.Runner
 	apiServer *api.Server
 
-	// lastConfigHash and lastSecretHash track whether config/secrets
-	// have changed since the last reconciliation.
-	lastConfigHash [sha256.Size]byte
+	// lastSecretHash tracks whether secrets have changed globally.
 	lastSecretHash [sha256.Size]byte
 }
 
@@ -117,8 +132,10 @@ func NewDaemon(configPath string) *Daemon {
 		apiSocketPath:     DefaultAPISocketPath,
 		tmuxSocketPath:    TmuxSocketPath,
 		reconcileInterval: DefaultReconcileInterval,
+		launchConcurrency: DefaultLaunchConcurrency,
 		sandboxStateDir:   DefaultSandboxStateDir,
 		sandboxBundleDir:  DefaultSandboxBundleDir,
+		agents:            make(map[string]*managedAgent),
 	}
 }
 
@@ -158,6 +175,14 @@ func (d *Daemon) SetReconcileInterval(interval time.Duration) {
 	d.reconcileInterval = interval
 }
 
+// SetLaunchConcurrency overrides the default maximum number of
+// concurrent agent launches.
+func (d *Daemon) SetLaunchConcurrency(n int) {
+	if n > 0 {
+		d.launchConcurrency = n
+	}
+}
+
 // SetDebug enables or disables debug logging. When enabled, the
 // manager logs the full command, environment variable names, and
 // captures tmux pane output when agents exit.
@@ -166,16 +191,27 @@ func (d *Daemon) SetDebug(debug bool) {
 }
 
 // AgentStatuses implements api.AgentProvider. It returns the status of
-// all managed agents (currently at most one).
+// all managed agents.
 func (d *Daemon) AgentStatuses() []api.AgentStatus {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if d.manager == nil {
+	if len(d.agents) == 0 {
 		return nil
 	}
 
-	return []api.AgentStatus{d.manager.Status()}
+	// Return in deterministic order by agent name.
+	names := make([]string, 0, len(d.agents))
+	for name := range d.agents {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	statuses := make([]api.AgentStatus, 0, len(d.agents))
+	for _, name := range names {
+		statuses = append(statuses, d.agents[name].manager.Status())
+	}
+	return statuses
 }
 
 // Run starts the agentd daemon and blocks until the context is cancelled.
@@ -185,7 +221,7 @@ func (d *Daemon) AgentStatuses() []api.AgentStatus {
 //  2. Start the tmux server
 //  3. Start the API server
 //  4. Run the reconciliation loop (reads config + secrets, converges)
-//  5. On shutdown: stop manager, stop API, stop tmux
+//  5. On shutdown: stop all managers, stop API, stop tmux
 func (d *Daemon) Run(ctx context.Context) error {
 	log.Println("agentd: initializing agent manager")
 
@@ -238,20 +274,30 @@ func (d *Daemon) Run(ctx context.Context) error {
 	}()
 
 	// 4. Run the reconciliation loop.
-	log.Printf("agentd: starting reconciliation loop (interval=%s)", d.reconcileInterval)
+	log.Printf("agentd: starting reconciliation loop (interval=%s, max-concurrent-launches=%d)", d.reconcileInterval, d.launchConcurrency)
 	d.reconcileLoop(ctx)
 
-	// 5. Graceful shutdown.
+	// 5. Graceful shutdown — stop all agents.
 	log.Println("agentd: shutting down")
 	d.mu.Lock()
-	mgr := d.manager
+	agentsCopy := make(map[string]*managedAgent, len(d.agents))
+	maps.Copy(agentsCopy, d.agents)
+	d.agents = make(map[string]*managedAgent)
 	d.mu.Unlock()
 
-	if mgr != nil {
-		log.Println("agentd: stopping agent")
-		if err := mgr.Stop(); err != nil {
-			log.Printf("agentd: error stopping agent: %v", err)
+	if len(agentsCopy) > 0 {
+		log.Printf("agentd: stopping %d agents", len(agentsCopy))
+		var wg sync.WaitGroup
+		for name, a := range agentsCopy {
+			wg.Add(1)
+			go func(name string, a *managedAgent) {
+				defer wg.Done()
+				if err := a.manager.Stop(); err != nil {
+					log.Printf("agentd: error stopping agent %s: %v", name, err)
+				}
+			}(name, a)
 		}
+		wg.Wait()
 	}
 
 	log.Println("agentd: shutdown complete")
@@ -278,8 +324,9 @@ func (d *Daemon) reconcileLoop(ctx context.Context) {
 }
 
 // reconcile reads the current desired state (config file + secrets) and
-// converges. If the config or secrets have changed since the last
-// reconciliation, the agent is restarted with the new values.
+// converges. It diffs the desired agent list against running agents and
+// starts/stops/restarts agents as needed. Agent launches are throttled
+// through a worker pool to prevent resource exhaustion.
 func (d *Daemon) reconcile(ctx context.Context) {
 	// Read config file as raw bytes so we can hash before parsing.
 	cfgBytes, err := os.ReadFile(d.configPath)
@@ -289,7 +336,7 @@ func (d *Daemon) reconcile(ctx context.Context) {
 		return
 	}
 
-	cfg, err := config.ParseConfig(string(cfgBytes))
+	agents, err := config.ParseConfig(string(cfgBytes))
 	if err != nil {
 		log.Printf("agentd: reconcile: invalid config: %v", err)
 		return
@@ -303,45 +350,156 @@ func (d *Daemon) reconcile(ctx context.Context) {
 		secretEnv = make(map[string]string)
 	}
 
-	// Compute hashes to detect changes.
-	configHash := sha256.Sum256(cfgBytes)
+	// Detect global secret changes.
 	secretHash := hashSecrets(secretEnv)
-
 	d.mu.Lock()
-	changed := configHash != d.lastConfigHash || secretHash != d.lastSecretHash
-	hasManager := d.manager != nil
+	secretsChanged := secretHash != d.lastSecretHash
+	d.lastSecretHash = secretHash
 	d.mu.Unlock()
 
-	if !changed && hasManager {
-		// No changes and agent is already running — nothing to do.
-		return
-	}
+	// Build desired state: map of agent name -> config + hash.
+	desired := make(map[string]desiredAgent, len(agents))
+	for i := range agents {
+		// Hash includes the individual agent config bytes plus the secret hash,
+		// so a change to either triggers a restart for that agent.
+		h := sha256.New()
+		h.Write([]byte(fmt.Sprintf("%+v", agents[i])))
+		h.Write(secretHash[:])
+		var hash [sha256.Size]byte
+		copy(hash[:], h.Sum(nil))
 
-	// If the desired state changed and we have a running manager, stop it.
-	if changed && hasManager {
-		log.Println("agentd: reconcile: config or secrets changed, restarting agent")
-		d.mu.Lock()
-		mgr := d.manager
-		d.manager = nil
-		d.mu.Unlock()
-
-		if err := mgr.Stop(); err != nil {
-			log.Printf("agentd: reconcile: error stopping previous agent: %v", err)
+		desired[agents[i].Name] = desiredAgent{
+			config: &agents[i],
+			hash:   hash,
 		}
 	}
 
+	// Diff: determine which agents to stop, start, or leave alone.
+	d.mu.Lock()
+	var toStop []string
+	var toStart []desiredAgent
+
+	// Find agents to remove (running but not in desired state).
+	for name := range d.agents {
+		if _, ok := desired[name]; !ok {
+			toStop = append(toStop, name)
+		}
+	}
+
+	// Find agents to start or restart.
+	for name, da := range desired {
+		existing, ok := d.agents[name]
+		if !ok {
+			// New agent.
+			toStart = append(toStart, da)
+		} else if existing.configHash != da.hash || secretsChanged {
+			// Config or secrets changed — restart.
+			toStop = append(toStop, name)
+			toStart = append(toStart, da)
+		}
+		// Otherwise: unchanged, leave running.
+	}
+	d.mu.Unlock()
+
+	// Nothing to do.
+	if len(toStop) == 0 && len(toStart) == 0 {
+		return
+	}
+
+	// Stop removed/changed agents.
+	if len(toStop) > 0 {
+		log.Printf("agentd: reconcile: stopping %d agents", len(toStop))
+		var wg sync.WaitGroup
+		for _, name := range toStop {
+			d.mu.Lock()
+			a, ok := d.agents[name]
+			if ok {
+				delete(d.agents, name)
+			}
+			d.mu.Unlock()
+
+			if ok {
+				wg.Add(1)
+				go func(name string, a *managedAgent) {
+					defer wg.Done()
+					log.Printf("agentd: reconcile: stopping agent %s", name)
+					if err := a.manager.Stop(); err != nil {
+						log.Printf("agentd: reconcile: error stopping agent %s: %v", name, err)
+					}
+				}(name, a)
+			}
+		}
+		wg.Wait()
+	}
+
+	// Launch new/changed agents through the worker pool.
+	if len(toStart) > 0 {
+		log.Printf("agentd: reconcile: launching %d agents (concurrency=%d)", len(toStart), d.launchConcurrency)
+		sem := make(chan struct{}, d.launchConcurrency)
+		var wg sync.WaitGroup
+
+		for _, da := range toStart {
+			wg.Add(1)
+			go func(da desiredAgent) {
+				defer wg.Done()
+
+				// Acquire semaphore slot.
+				select {
+				case sem <- struct{}{}:
+					defer func() { <-sem }()
+				case <-ctx.Done():
+					return
+				}
+
+				mgr, err := d.createManager(da.config, secretEnv)
+				if err != nil {
+					log.Printf("agentd: reconcile: error creating manager for %s: %v", da.config.Name, err)
+					return
+				}
+
+				if err := mgr.Start(ctx); err != nil {
+					log.Printf("agentd: reconcile: error starting agent %s: %v", da.config.Name, err)
+					return
+				}
+
+				d.mu.Lock()
+				d.agents[da.config.Name] = &managedAgent{
+					manager:    mgr,
+					configHash: da.hash,
+				}
+				d.mu.Unlock()
+
+				log.Printf("agentd: reconcile: agent %s running", da.config.Name)
+			}(da)
+		}
+
+		wg.Wait()
+	}
+
+	d.mu.Lock()
+	total := len(d.agents)
+	d.mu.Unlock()
+	log.Printf("agentd: reconcile: %d agents running", total)
+}
+
+// desiredAgent pairs a config with its hash for diff comparison.
+type desiredAgent struct {
+	config *config.AgentConfig
+	hash   [sha256.Size]byte
+}
+
+// createManager creates the appropriate AgentManager for the given config.
+func (d *Daemon) createManager(cfg *config.AgentConfig, secretEnv map[string]string) (AgentManager, error) {
 	// Resolve harness.
 	h, err := harness.Get(cfg.Harness)
 	if err != nil {
-		log.Printf("agentd: reconcile: %v", err)
-		return
+		return nil, err
 	}
 
 	// Resolve prompt.
 	prompt, err := cfg.ResolvePrompt()
 	if err != nil {
-		log.Printf("agentd: reconcile: error resolving prompt: %v", err)
-		return
+		return nil, fmt.Errorf("resolving prompt: %w", err)
 	}
 
 	// Merge environment: secrets first, then agent env (agent env overrides).
@@ -349,16 +507,12 @@ func (d *Daemon) reconcile(ctx context.Context) {
 	maps.Copy(mergedEnv, secretEnv)
 	maps.Copy(mergedEnv, cfg.Env)
 
-	// Create the appropriate manager based on agent type.
-	var mgr AgentManager
-
 	switch cfg.Type {
 	case config.AgentTypeSandboxed:
 		if d.runner == nil {
-			log.Println("agentd: reconcile: type=sandboxed but sandbox runner not initialized (this should not happen)")
-			return
+			return nil, fmt.Errorf("type=sandboxed but sandbox runner not initialized")
 		}
-		mgr = sandbox.NewManager(sandbox.ManagerOpts{
+		mgr := sandbox.NewManager(sandbox.ManagerOpts{
 			Config:        cfg,
 			Harness:       h,
 			Runner:        d.runner,
@@ -368,10 +522,11 @@ func (d *Daemon) reconcile(ctx context.Context) {
 			BundleBaseDir: d.sandboxBundleDir,
 			ExtraPackages: cfg.ExtraPackages,
 		})
-		log.Printf("agentd: reconcile: launching sandboxed agent harness=%s", cfg.Harness)
+		log.Printf("agentd: creating sandboxed agent %s harness=%s", cfg.Name, cfg.Harness)
+		return mgr, nil
 
 	case config.AgentTypeNative:
-		mgr = native.NewManager(native.Opts{
+		mgr := native.NewManager(native.Opts{
 			Config:  cfg,
 			Harness: h,
 			Tmux:    d.tmux,
@@ -379,25 +534,12 @@ func (d *Daemon) reconcile(ctx context.Context) {
 			Prompt:  prompt,
 			Debug:   d.debug,
 		})
-		log.Printf("agentd: reconcile: launching native agent harness=%s session=%s", cfg.Harness, cfg.Session)
+		log.Printf("agentd: creating native agent %s harness=%s session=%s", cfg.Name, cfg.Harness, cfg.Session)
+		return mgr, nil
 
 	default:
-		log.Printf("agentd: reconcile: unknown agent type %q", cfg.Type)
-		return
+		return nil, fmt.Errorf("unknown agent type %q", cfg.Type)
 	}
-
-	if err := mgr.Start(ctx); err != nil {
-		log.Printf("agentd: reconcile: error starting agent: %v", err)
-		return
-	}
-
-	d.mu.Lock()
-	d.manager = mgr
-	d.lastConfigHash = configHash
-	d.lastSecretHash = secretHash
-	d.mu.Unlock()
-
-	log.Println("agentd: reconcile: agent running")
 }
 
 // hashSecrets produces a deterministic hash of a secrets map by sorting

--- a/agentd/agentd_test.go
+++ b/agentd/agentd_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Daemon", func() {
 	})
 
 	Describe("AgentStatuses", func() {
-		It("should return nil when no manager is running", func() {
+		It("should return nil when no agents are running", func() {
 			d := agentd.NewDaemon("")
 			statuses := d.AgentStatuses()
 			Expect(statuses).To(BeNil())
@@ -49,6 +49,19 @@ var _ = Describe("Daemon", func() {
 		})
 	})
 
+	Describe("SetLaunchConcurrency", func() {
+		It("should not panic when setting concurrency", func() {
+			d := agentd.NewDaemon("")
+			Expect(func() { d.SetLaunchConcurrency(100) }).NotTo(Panic())
+		})
+
+		It("should ignore non-positive values", func() {
+			d := agentd.NewDaemon("")
+			Expect(func() { d.SetLaunchConcurrency(0) }).NotTo(Panic())
+			Expect(func() { d.SetLaunchConcurrency(-1) }).NotTo(Panic())
+		})
+	})
+
 	Describe("Constants", func() {
 		It("should reference the correct secret directory", func() {
 			Expect(agentd.SecretDir).To(Equal("/run/stereos/secrets"))
@@ -64,6 +77,10 @@ var _ = Describe("Daemon", func() {
 
 		It("should reference the correct default config path", func() {
 			Expect(agentd.DefaultConfigPath).To(Equal("/etc/stereos/jcard.toml"))
+		})
+
+		It("should have a default launch concurrency", func() {
+			Expect(agentd.DefaultLaunchConcurrency).To(Equal(50))
 		})
 	})
 })

--- a/jcard.toml
+++ b/jcard.toml
@@ -1,3 +1,3 @@
-[agent]
+[[agents]]
 harness = "opencode"
 prompt = "Hello world!"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// Package config handles parsing and validation of the [agent] section
+// Package config handles parsing and validation of the [[agents]] section
 // from jcard.toml configuration files used by agentd.
 package config
 
@@ -67,8 +67,12 @@ var harnessSet = map[string]bool{
 	"custom":      true,
 }
 
-// AgentConfig represents the [agent] section of a jcard.toml file.
+// AgentConfig represents a single entry in the [[agents]] array of a jcard.toml file.
 type AgentConfig struct {
+	// Name is a unique identifier for this agent. If omitted, a name is
+	// auto-generated from the harness name (e.g. "claude-code", "claude-code-1").
+	Name string `toml:"name,omitempty"`
+
 	// Type selects the agent execution mode.
 	// "sandboxed" (default) runs in a gVisor container with /nix/store sharing.
 	// "native" runs directly on the host in a tmux session.
@@ -124,19 +128,25 @@ type AgentConfig struct {
 	// into /nix/store at agent launch time. Only used for sandboxed agents.
 	ExtraPackages []string `toml:"extra_packages,omitempty"`
 
+	// Replicas is the number of identical agents to launch from this
+	// spec. Defaults to 1. When > 1, each replica gets a unique name
+	// suffixed with its index (e.g. "reviewer-0", "reviewer-1").
+	// Useful for launching swarms of agents performing the same task.
+	Replicas int `toml:"replicas,omitempty"`
+
 	// Env holds environment variables set only for the agent process.
 	Env map[string]string `toml:"env,omitempty"`
 }
 
 // jcardFile is the top-level structure of a jcard.toml, used for partial
-// parsing. We only care about the [agent] section.
+// parsing. We only care about the [[agents]] section.
 type jcardFile struct {
-	Agent AgentConfig `toml:"agent"`
+	Agents []AgentConfig `toml:"agents"`
 }
 
-// LoadConfig reads and parses the [agent] section from a jcard.toml file
+// LoadConfig reads and parses the [[agents]] section from a jcard.toml file
 // at the given path. It applies defaults and validates the configuration.
-func LoadConfig(path string) (*AgentConfig, error) {
+func LoadConfig(path string) ([]AgentConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading config %s: %w", path, err)
@@ -145,25 +155,39 @@ func LoadConfig(path string) (*AgentConfig, error) {
 	return ParseConfig(string(data))
 }
 
-// ParseConfig parses the [agent] section from TOML content, applies
-// defaults, and validates the configuration.
-func ParseConfig(content string) (*AgentConfig, error) {
+// ParseConfig parses the [[agents]] section from TOML content, applies
+// defaults, and validates each agent configuration.
+func ParseConfig(content string) ([]AgentConfig, error) {
 	var jcard jcardFile
 	if _, err := toml.Decode(content, &jcard); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
 
-	cfg := &jcard.Agent
-	cfg.applyDefaults()
+	// Apply defaults, expand replicas, then assign names.
+	for i := range jcard.Agents {
+		jcard.Agents[i].applyDefaults()
+	}
+	jcard.Agents = expandReplicas(jcard.Agents)
+	assignAgentNames(jcard.Agents)
 
-	if err := cfg.Validate(); err != nil {
-		return nil, err
+	// Validate each agent.
+	namesSeen := make(map[string]bool, len(jcard.Agents))
+	for i := range jcard.Agents {
+		if err := jcard.Agents[i].Validate(); err != nil {
+			return nil, fmt.Errorf("agents[%d]: %w", i, err)
+		}
+		if namesSeen[jcard.Agents[i].Name] {
+			return nil, fmt.Errorf("agents[%d]: duplicate agent name %q", i, jcard.Agents[i].Name)
+		}
+		namesSeen[jcard.Agents[i].Name] = true
 	}
 
-	return cfg, nil
+	return jcard.Agents, nil
 }
 
 // applyDefaults fills in default values for unset fields.
+// Note: Name and Session are finalized after assignAgentNames runs,
+// since Name may be auto-generated from the harness.
 func (c *AgentConfig) applyDefaults() {
 	if c.Type == "" {
 		c.Type = DefaultAgentType
@@ -177,9 +201,6 @@ func (c *AgentConfig) applyDefaults() {
 	if c.GracePeriod == "" {
 		c.GracePeriod = DefaultGracePeriod
 	}
-	if c.Session == "" {
-		c.Session = c.Harness
-	}
 	if c.Type == AgentTypeSandboxed {
 		if c.Memory == "" {
 			c.Memory = DefaultMemory
@@ -188,8 +209,98 @@ func (c *AgentConfig) applyDefaults() {
 			c.PidLimit = DefaultPidLimit
 		}
 	}
+	if c.Replicas <= 0 {
+		c.Replicas = 1
+	}
 	if c.Env == nil {
 		c.Env = make(map[string]string)
+	}
+}
+
+// expandReplicas expands agent entries with Replicas > 1 into individual
+// agent entries. Each replica is a copy of the original with a unique
+// name suffix. For replicas=1, the entry is left unchanged.
+//
+// Naming rules:
+//   - replicas=1, name="rev"   -> "rev" (unchanged)
+//   - replicas=3, name="rev"   -> "rev-0", "rev-1", "rev-2"
+//   - replicas=3, name=""      -> name left empty (assignAgentNames handles it later)
+func expandReplicas(agents []AgentConfig) []AgentConfig {
+	// Fast path: if all agents have replicas=1, return as-is.
+	needsExpansion := false
+	total := 0
+	for i := range agents {
+		if agents[i].Replicas > 1 {
+			needsExpansion = true
+		}
+		total += agents[i].Replicas
+	}
+	if !needsExpansion {
+		return agents
+	}
+
+	expanded := make([]AgentConfig, 0, total)
+	for _, a := range agents {
+		if a.Replicas <= 1 {
+			expanded = append(expanded, a)
+			continue
+		}
+
+		baseName := a.Name
+		for j := 0; j < a.Replicas; j++ {
+			replica := a
+			replica.Replicas = 1
+			if baseName != "" {
+				replica.Name = fmt.Sprintf("%s-%d", baseName, j)
+			}
+			// If baseName is empty, leave Name empty — assignAgentNames
+			// will handle it and produce unique names from the harness.
+			// Session is also left empty so it defaults to the final name.
+			replica.Session = ""
+			// Deep-copy the env map so replicas don't share a reference.
+			if a.Env != nil {
+				replica.Env = make(map[string]string, len(a.Env))
+				for k, v := range a.Env {
+					replica.Env[k] = v
+				}
+			}
+			expanded = append(expanded, replica)
+		}
+	}
+	return expanded
+}
+
+// assignAgentNames fills in Name and Session for agents that don't have them set.
+// The first agent with a given harness gets the harness name (e.g. "claude-code").
+// Subsequent unnamed agents with the same harness get "<harness>-1", "<harness>-2", etc.
+func assignAgentNames(agents []AgentConfig) {
+	// Count how many unnamed agents use each harness.
+	harnessCount := make(map[string]int)
+	for i := range agents {
+		if agents[i].Name == "" {
+			harnessCount[agents[i].Harness]++
+		}
+	}
+
+	// Assign names.
+	harnessIdx := make(map[string]int)
+	for i := range agents {
+		if agents[i].Name == "" {
+			h := agents[i].Harness
+			idx := harnessIdx[h]
+			harnessIdx[h]++
+
+			if harnessCount[h] == 1 {
+				agents[i].Name = h
+			} else {
+				agents[i].Name = fmt.Sprintf("%s-%d", h, idx)
+			}
+		}
+
+		// Default session to agent name (not harness) for uniqueness.
+		if agents[i].Session == "" {
+			agents[i].Session = agents[i].Name
+		}
 	}
 }
 
@@ -252,6 +363,10 @@ func (c *AgentConfig) Validate() error {
 	// extra_packages is only valid for sandboxed agents.
 	if c.Type != AgentTypeSandboxed && len(c.ExtraPackages) > 0 {
 		return fmt.Errorf("agent.extra_packages is only supported for type=sandboxed")
+	}
+
+	if c.Replicas < 1 {
+		return fmt.Errorf("agent.replicas must be >= 1, got %d", c.Replicas)
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,26 +18,29 @@ func TestConfig(t *testing.T) {
 
 var _ = Describe("Config", func() {
 	Describe("ParseConfig", func() {
-		It("should parse a minimal valid config", func() {
+		It("should parse a minimal valid config with one agent", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 `
-			cfg, err := config.ParseConfig(toml)
+			agents, err := config.ParseConfig(toml)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(cfg.Harness).To(Equal("claude-code"))
-			Expect(cfg.Type).To(Equal(config.AgentTypeSandboxed))
-			Expect(cfg.Workdir).To(Equal("/home/agent/workspace"))
-			Expect(cfg.Restart).To(Equal(config.RestartNo))
-			Expect(cfg.GracePeriod).To(Equal("30s"))
-			Expect(cfg.Session).To(Equal("claude-code"))
-			Expect(cfg.Memory).To(Equal("2GiB"))
-			Expect(cfg.PidLimit).To(Equal(512))
+			Expect(agents).To(HaveLen(1))
+			Expect(agents[0].Harness).To(Equal("claude-code"))
+			Expect(agents[0].Type).To(Equal(config.AgentTypeSandboxed))
+			Expect(agents[0].Workdir).To(Equal("/home/agent/workspace"))
+			Expect(agents[0].Restart).To(Equal(config.RestartNo))
+			Expect(agents[0].GracePeriod).To(Equal("30s"))
+			Expect(agents[0].Name).To(Equal("claude-code"))
+			Expect(agents[0].Session).To(Equal("claude-code"))
+			Expect(agents[0].Memory).To(Equal("2GiB"))
+			Expect(agents[0].PidLimit).To(Equal(512))
 		})
 
 		It("should parse a fully specified config", func() {
 			toml := `
-[agent]
+[[agents]]
+name = "my-agent"
 harness = "opencode"
 prompt = "fix the tests"
 workdir = "/home/agent/project"
@@ -47,12 +50,15 @@ timeout = "2h"
 grace_period = "1m"
 session = "my-session"
 
-[agent.env]
+[agents.env]
 FOO = "bar"
 BAZ = "qux"
 `
-			cfg, err := config.ParseConfig(toml)
+			agents, err := config.ParseConfig(toml)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(agents).To(HaveLen(1))
+			cfg := agents[0]
+			Expect(cfg.Name).To(Equal("my-agent"))
 			Expect(cfg.Harness).To(Equal("opencode"))
 			Expect(cfg.Prompt).To(Equal("fix the tests"))
 			Expect(cfg.Workdir).To(Equal("/home/agent/project"))
@@ -65,9 +71,70 @@ BAZ = "qux"
 			Expect(cfg.Env).To(HaveKeyWithValue("BAZ", "qux"))
 		})
 
+		It("should parse multiple agents", func() {
+			toml := `
+[[agents]]
+name = "reviewer"
+harness = "claude-code"
+prompt = "review the code"
+
+[[agents]]
+name = "coder"
+harness = "opencode"
+prompt = "implement the feature"
+
+[[agents]]
+harness = "gemini-cli"
+prompt = "security audit"
+`
+			agents, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(agents).To(HaveLen(3))
+			Expect(agents[0].Name).To(Equal("reviewer"))
+			Expect(agents[1].Name).To(Equal("coder"))
+			Expect(agents[2].Name).To(Equal("gemini-cli"))
+		})
+
+		It("should auto-generate unique names for duplicate harnesses", func() {
+			toml := `
+[[agents]]
+harness = "claude-code"
+prompt = "task one"
+
+[[agents]]
+harness = "claude-code"
+prompt = "task two"
+`
+			agents, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(agents).To(HaveLen(2))
+			Expect(agents[0].Name).To(Equal("claude-code-0"))
+			Expect(agents[1].Name).To(Equal("claude-code-1"))
+		})
+
+		It("should default session to agent name", func() {
+			toml := `
+[[agents]]
+name = "my-reviewer"
+harness = "claude-code"
+`
+			agents, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(agents[0].Session).To(Equal("my-reviewer"))
+		})
+
+		It("should return empty slice when no agents defined", func() {
+			toml := `
+mixtape = "base"
+`
+			agents, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(agents).To(BeEmpty())
+		})
+
 		It("should reject missing harness", func() {
 			toml := `
-[agent]
+[[agents]]
 prompt = "do stuff"
 `
 			_, err := config.ParseConfig(toml)
@@ -77,7 +144,7 @@ prompt = "do stuff"
 
 		It("should reject unknown harness", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "unknown-thing"
 `
 			_, err := config.ParseConfig(toml)
@@ -87,7 +154,7 @@ harness = "unknown-thing"
 
 		It("should reject invalid restart policy", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 restart = "sometimes"
 `
@@ -98,7 +165,7 @@ restart = "sometimes"
 
 		It("should reject invalid timeout duration", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 timeout = "not-a-duration"
 `
@@ -109,7 +176,7 @@ timeout = "not-a-duration"
 
 		It("should reject invalid grace_period duration", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 grace_period = "bad"
 `
@@ -120,7 +187,7 @@ grace_period = "bad"
 
 		It("should reject negative max_restarts", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 max_restarts = -1
 `
@@ -129,21 +196,36 @@ max_restarts = -1
 			Expect(err.Error()).To(ContainSubstring("max_restarts"))
 		})
 
+		It("should reject duplicate agent names", func() {
+			toml := `
+[[agents]]
+name = "same-name"
+harness = "claude-code"
+
+[[agents]]
+name = "same-name"
+harness = "opencode"
+`
+			_, err := config.ParseConfig(toml)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("duplicate agent name"))
+		})
+
 		It("should accept all valid harness types", func() {
 			for _, h := range []string{"claude-code", "opencode", "gemini-cli", "custom"} {
-				toml := "[agent]\nharness = \"" + h + "\""
-				cfg, err := config.ParseConfig(toml)
+				toml := "[[agents]]\nharness = \"" + h + "\""
+				agents, err := config.ParseConfig(toml)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(cfg.Harness).To(Equal(h))
+				Expect(agents[0].Harness).To(Equal(h))
 			}
 		})
 
 		It("should accept all valid restart policies", func() {
 			for _, r := range []string{"no", "on-failure", "always"} {
-				toml := "[agent]\nharness = \"claude-code\"\nrestart = \"" + r + "\""
-				cfg, err := config.ParseConfig(toml)
+				toml := "[[agents]]\nharness = \"claude-code\"\nrestart = \"" + r + "\""
+				agents, err := config.ParseConfig(toml)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(string(cfg.Restart)).To(Equal(r))
+				Expect(string(agents[0].Restart)).To(Equal(r))
 			}
 		})
 
@@ -155,44 +237,44 @@ mixtape = "base"
 cpus = 2
 memory = "4GiB"
 
-[agent]
+[[agents]]
 harness = "claude-code"
 `
-			cfg, err := config.ParseConfig(toml)
+			agents, err := config.ParseConfig(toml)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(cfg.Harness).To(Equal("claude-code"))
+			Expect(agents[0].Harness).To(Equal("claude-code"))
 		})
 
 		It("should parse type=sandboxed explicitly", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 type = "sandboxed"
 `
-			cfg, err := config.ParseConfig(toml)
+			agents, err := config.ParseConfig(toml)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(cfg.Type).To(Equal(config.AgentTypeSandboxed))
-			Expect(cfg.Memory).To(Equal("2GiB"))
-			Expect(cfg.PidLimit).To(Equal(512))
+			Expect(agents[0].Type).To(Equal(config.AgentTypeSandboxed))
+			Expect(agents[0].Memory).To(Equal("2GiB"))
+			Expect(agents[0].PidLimit).To(Equal(512))
 		})
 
 		It("should parse type=native", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 type = "native"
 `
-			cfg, err := config.ParseConfig(toml)
+			agents, err := config.ParseConfig(toml)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(cfg.Type).To(Equal(config.AgentTypeNative))
+			Expect(agents[0].Type).To(Equal(config.AgentTypeNative))
 			// Native agents do not get sandbox defaults.
-			Expect(cfg.Memory).To(BeEmpty())
-			Expect(cfg.PidLimit).To(Equal(0))
+			Expect(agents[0].Memory).To(BeEmpty())
+			Expect(agents[0].PidLimit).To(Equal(0))
 		})
 
 		It("should reject invalid type", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 type = "docker"
 `
@@ -203,21 +285,21 @@ type = "docker"
 
 		It("should parse sandbox-specific fields", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 type = "sandboxed"
 memory = "4GiB"
 pid_limit = 1024
 `
-			cfg, err := config.ParseConfig(toml)
+			agents, err := config.ParseConfig(toml)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(cfg.Memory).To(Equal("4GiB"))
-			Expect(cfg.PidLimit).To(Equal(1024))
+			Expect(agents[0].Memory).To(Equal("4GiB"))
+			Expect(agents[0].PidLimit).To(Equal(1024))
 		})
 
 		It("should reject invalid memory format", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 type = "sandboxed"
 memory = "lots"
@@ -229,7 +311,7 @@ memory = "lots"
 
 		It("should reject negative pid_limit", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 type = "sandboxed"
 pid_limit = -1
@@ -241,42 +323,42 @@ pid_limit = -1
 
 		It("should parse extra_packages for sandboxed agents", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 type = "sandboxed"
 extra_packages = ["ripgrep", "fd", "python311"]
 `
-			cfg, err := config.ParseConfig(toml)
+			agents, err := config.ParseConfig(toml)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(cfg.ExtraPackages).To(Equal([]string{"ripgrep", "fd", "python311"}))
+			Expect(agents[0].ExtraPackages).To(Equal([]string{"ripgrep", "fd", "python311"}))
 		})
 
 		It("should accept empty extra_packages", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 type = "sandboxed"
 extra_packages = []
 `
-			cfg, err := config.ParseConfig(toml)
+			agents, err := config.ParseConfig(toml)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(cfg.ExtraPackages).To(BeEmpty())
+			Expect(agents[0].ExtraPackages).To(BeEmpty())
 		})
 
 		It("should accept sandboxed agent without extra_packages", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 type = "sandboxed"
 `
-			cfg, err := config.ParseConfig(toml)
+			agents, err := config.ParseConfig(toml)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(cfg.ExtraPackages).To(BeNil())
+			Expect(agents[0].ExtraPackages).To(BeNil())
 		})
 
 		It("should reject extra_packages with empty string entries", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 type = "sandboxed"
 extra_packages = ["ripgrep", "", "fd"]
@@ -288,7 +370,7 @@ extra_packages = ["ripgrep", "", "fd"]
 
 		It("should reject extra_packages for native agents", func() {
 			toml := `
-[agent]
+[[agents]]
 harness = "claude-code"
 type = "native"
 extra_packages = ["ripgrep"]
@@ -297,6 +379,27 @@ extra_packages = ["ripgrep"]
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("extra_packages is only supported for type=sandboxed"))
 		})
+
+		It("should parse mixed native and sandboxed agents", func() {
+			toml := `
+[[agents]]
+name = "native-claude"
+harness = "claude-code"
+type = "native"
+
+[[agents]]
+name = "sandbox-opencode"
+harness = "opencode"
+type = "sandboxed"
+memory = "4GiB"
+`
+			agents, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(agents).To(HaveLen(2))
+			Expect(agents[0].Type).To(Equal(config.AgentTypeNative))
+			Expect(agents[1].Type).To(Equal(config.AgentTypeSandboxed))
+			Expect(agents[1].Memory).To(Equal("4GiB"))
+		})
 	})
 
 	Describe("LoadConfig", func() {
@@ -304,16 +407,17 @@ extra_packages = ["ripgrep"]
 			dir := GinkgoT().TempDir()
 			path := filepath.Join(dir, "jcard.toml")
 			err := os.WriteFile(path, []byte(`
-[agent]
+[[agents]]
 harness = "gemini-cli"
 prompt = "hello world"
 `), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
-			cfg, err := config.LoadConfig(path)
+			agents, err := config.LoadConfig(path)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(cfg.Harness).To(Equal("gemini-cli"))
-			Expect(cfg.Prompt).To(Equal("hello world"))
+			Expect(agents).To(HaveLen(1))
+			Expect(agents[0].Harness).To(Equal("gemini-cli"))
+			Expect(agents[0].Prompt).To(Equal("hello world"))
 		})
 
 		It("should return error for non-existent file", func() {
@@ -469,6 +573,138 @@ prompt = "hello world"
 			n, err := config.ParseMemory("1.5GiB")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(n).To(Equal(int64(1.5 * 1024 * 1024 * 1024)))
+		})
+	})
+
+	Describe("Replicas", func() {
+		It("should default replicas to 1", func() {
+			toml := `
+[[agents]]
+harness = "claude-code"
+`
+			agents, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(agents).To(HaveLen(1))
+			Expect(agents[0].Replicas).To(Equal(1))
+			Expect(agents[0].Name).To(Equal("claude-code"))
+		})
+
+		It("should expand replicas=1 without suffix", func() {
+			toml := `
+[[agents]]
+name = "reviewer"
+harness = "claude-code"
+replicas = 1
+`
+			agents, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(agents).To(HaveLen(1))
+			Expect(agents[0].Name).To(Equal("reviewer"))
+		})
+
+		It("should expand named replicas with index suffix", func() {
+			toml := `
+[[agents]]
+name = "reviewer"
+harness = "claude-code"
+prompt = "review code"
+replicas = 3
+`
+			agents, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(agents).To(HaveLen(3))
+			Expect(agents[0].Name).To(Equal("reviewer-0"))
+			Expect(agents[1].Name).To(Equal("reviewer-1"))
+			Expect(agents[2].Name).To(Equal("reviewer-2"))
+			// Each replica should have the same harness and prompt.
+			for _, a := range agents {
+				Expect(a.Harness).To(Equal("claude-code"))
+				Expect(a.Prompt).To(Equal("review code"))
+				Expect(a.Replicas).To(Equal(1))
+			}
+		})
+
+		It("should expand unnamed replicas and auto-generate names", func() {
+			toml := `
+[[agents]]
+harness = "claude-code"
+replicas = 3
+`
+			agents, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(agents).To(HaveLen(3))
+			Expect(agents[0].Name).To(Equal("claude-code-0"))
+			Expect(agents[1].Name).To(Equal("claude-code-1"))
+			Expect(agents[2].Name).To(Equal("claude-code-2"))
+		})
+
+		It("should handle mixed replicas and single agents", func() {
+			toml := `
+[[agents]]
+name = "lead"
+harness = "claude-code"
+
+[[agents]]
+name = "worker"
+harness = "opencode"
+replicas = 3
+`
+			agents, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(agents).To(HaveLen(4))
+			Expect(agents[0].Name).To(Equal("lead"))
+			Expect(agents[1].Name).To(Equal("worker-0"))
+			Expect(agents[2].Name).To(Equal("worker-1"))
+			Expect(agents[3].Name).To(Equal("worker-2"))
+		})
+
+		It("should deep-copy env maps across replicas", func() {
+			toml := `
+[[agents]]
+name = "worker"
+harness = "claude-code"
+replicas = 2
+
+[agents.env]
+KEY = "value"
+`
+			agents, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(agents).To(HaveLen(2))
+			// Verify both have the env var.
+			Expect(agents[0].Env).To(HaveKeyWithValue("KEY", "value"))
+			Expect(agents[1].Env).To(HaveKeyWithValue("KEY", "value"))
+			// Verify they are independent maps (deep copy).
+			agents[0].Env["EXTRA"] = "modified"
+			Expect(agents[1].Env).NotTo(HaveKey("EXTRA"))
+		})
+
+		It("should support large replica counts", func() {
+			toml := `
+[[agents]]
+name = "swarm"
+harness = "claude-code"
+replicas = 500
+`
+			agents, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(agents).To(HaveLen(500))
+			Expect(agents[0].Name).To(Equal("swarm-0"))
+			Expect(agents[499].Name).To(Equal("swarm-499"))
+		})
+
+		It("should set unique sessions for replicas", func() {
+			toml := `
+[[agents]]
+name = "worker"
+harness = "claude-code"
+replicas = 3
+`
+			agents, err := config.ParseConfig(toml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(agents[0].Session).To(Equal("worker-0"))
+			Expect(agents[1].Session).To(Equal("worker-1"))
+			Expect(agents[2].Session).To(Equal("worker-2"))
 		})
 	})
 

--- a/pkg/native/manager.go
+++ b/pkg/native/manager.go
@@ -119,7 +119,7 @@ func (s *Manager) Status() api.AgentStatus {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return api.AgentStatus{
-		Name:     s.harness.Name(),
+		Name:     s.config.Name,
 		Running:  s.running,
 		Session:  s.config.Session,
 		Restarts: s.restarts,
@@ -168,7 +168,7 @@ func (s *Manager) launchAgent() error {
 	s.lastErr = ""
 	s.mu.Unlock()
 
-	log.Printf("manager: agent %q launched in tmux session %q", s.harness.Name(), s.config.Session)
+	log.Printf("manager: agent %q launched in tmux session %q", s.config.Name, s.config.Session)
 	return nil
 }
 
@@ -255,17 +255,17 @@ func (s *Manager) run(ctx context.Context) {
 			s.running = false
 			s.mu.Unlock()
 
-			log.Printf("manager: agent %q exited", s.harness.Name())
+			log.Printf("manager: agent %q exited", s.config.Name)
 
 			// Evaluate restart policy.
 			if !s.shouldRestart() {
 				log.Printf("manager: not restarting agent %q (policy=%s, restarts=%d)",
-					s.harness.Name(), s.config.Restart, s.restarts)
+					s.config.Name, s.config.Restart, s.restarts)
 				return
 			}
 
 			s.restarts++
-			log.Printf("manager: restarting agent %q (attempt %d)", s.harness.Name(), s.restarts)
+			log.Printf("manager: restarting agent %q (attempt %d)", s.config.Name, s.restarts)
 
 			// Backoff before restart.
 			select {
@@ -275,7 +275,7 @@ func (s *Manager) run(ctx context.Context) {
 			}
 
 			if err := s.launchAgent(); err != nil {
-				log.Printf("manager: failed to restart agent %q: %v", s.harness.Name(), err)
+				log.Printf("manager: failed to restart agent %q: %v", s.config.Name, err)
 				s.mu.Lock()
 				s.lastErr = err.Error()
 				s.mu.Unlock()

--- a/pkg/native/manager_test.go
+++ b/pkg/native/manager_test.go
@@ -23,6 +23,7 @@ var _ = Describe("Manager", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cfg := &config.AgentConfig{
+				Name:        "claude-code",
 				Harness:     "claude-code",
 				Workdir:     "/home/agent/workspace",
 				Restart:     config.RestartNo,
@@ -48,6 +49,7 @@ var _ = Describe("Manager", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cfg := &config.AgentConfig{
+				Name:        "opencode",
 				Harness:     "opencode",
 				Workdir:     "/home/agent/workspace",
 				Restart:     config.RestartNo,
@@ -75,6 +77,7 @@ var _ = Describe("Manager", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			cfg := &config.AgentConfig{
+				Name:        "claude-code",
 				Harness:     "claude-code",
 				Workdir:     "/home/agent/workspace",
 				Restart:     config.RestartNo,

--- a/pkg/sandbox/manager.go
+++ b/pkg/sandbox/manager.go
@@ -142,7 +142,7 @@ func (m *Manager) Status() api.AgentStatus {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return api.AgentStatus{
-		Name:     m.harness.Name(),
+		Name:     m.config.Name,
 		Running:  m.running,
 		Session:  m.sandboxID, // sandbox ID serves as the "session" identifier
 		Restarts: m.restarts,
@@ -196,8 +196,8 @@ func (m *Manager) ensureClosure(ctx context.Context) error {
 
 // launchSandbox creates an OCI bundle and runs the sandbox.
 func (m *Manager) launchSandbox(ctx context.Context) error {
-	// Generate a deterministic sandbox ID.
-	m.sandboxID = fmt.Sprintf("agent-%s", m.harness.Name())
+	// Generate a deterministic sandbox ID from the agent name.
+	m.sandboxID = fmt.Sprintf("agent-%s", m.config.Name)
 
 	// Create the bundle directory.
 	m.bundleDir = filepath.Join(m.bundleBaseDir, m.sandboxID)
@@ -281,7 +281,7 @@ func (m *Manager) launchSandbox(ctx context.Context) error {
 	m.lastErr = ""
 	m.mu.Unlock()
 
-	log.Printf("sandbox: agent %q launched in sandbox %q", m.harness.Name(), m.sandboxID)
+	log.Printf("sandbox: agent %q launched in sandbox %q", m.config.Name, m.sandboxID)
 	return nil
 }
 
@@ -384,16 +384,16 @@ func (m *Manager) run(ctx context.Context) {
 			m.running = false
 			m.mu.Unlock()
 
-			log.Printf("sandbox: agent %q exited", m.harness.Name())
+			log.Printf("sandbox: agent %q exited", m.config.Name)
 
 			if !m.shouldRestart() {
 				log.Printf("sandbox: not restarting agent %q (policy=%s, restarts=%d)",
-					m.harness.Name(), m.config.Restart, m.restarts)
+					m.config.Name, m.config.Restart, m.restarts)
 				return
 			}
 
 			m.restarts++
-			log.Printf("sandbox: restarting agent %q (attempt %d)", m.harness.Name(), m.restarts)
+			log.Printf("sandbox: restarting agent %q (attempt %d)", m.config.Name, m.restarts)
 
 			// Clean up old sandbox before restart.
 			cleanupCtx := context.Background()
@@ -408,7 +408,7 @@ func (m *Manager) run(ctx context.Context) {
 			}
 
 			if err := m.launchSandbox(ctx); err != nil {
-				log.Printf("sandbox: failed to restart agent %q: %v", m.harness.Name(), err)
+				log.Printf("sandbox: failed to restart agent %q: %v", m.config.Name, err)
 				m.mu.Lock()
 				m.lastErr = err.Error()
 				m.mu.Unlock()

--- a/pkg/sandbox/sandbox_test.go
+++ b/pkg/sandbox/sandbox_test.go
@@ -358,6 +358,7 @@ var _ = Describe("Manager", func() {
 	It("should create a manager with valid options", func() {
 		runner, _ := sandbox.NewRunner("/usr/bin/runsc", "/tmp/state")
 		cfg := &config.AgentConfig{
+			Name:     "claude-code",
 			Type:     config.AgentTypeSandboxed,
 			Harness:  "claude-code",
 			Workdir:  "/home/agent/workspace",
@@ -383,6 +384,7 @@ var _ = Describe("Manager", func() {
 	It("should report correct initial status", func() {
 		runner, _ := sandbox.NewRunner("/usr/bin/runsc", "/tmp/state")
 		cfg := &config.AgentConfig{
+			Name:     "claude-code",
 			Type:     config.AgentTypeSandboxed,
 			Harness:  "claude-code",
 			Workdir:  "/home/agent/workspace",
@@ -408,6 +410,7 @@ var _ = Describe("Manager", func() {
 	It("should report zero restarts initially", func() {
 		runner, _ := sandbox.NewRunner("/usr/bin/runsc", "/tmp/state")
 		cfg := &config.AgentConfig{
+			Name:    "opencode",
 			Type:    config.AgentTypeSandboxed,
 			Harness: "opencode",
 			Restart: config.RestartNo,


### PR DESCRIPTION
* ✨ Introduces `replicas` for specifying number of agents that should come up for a certain `[[agents]]` jcard config.