### PR TITLE
🧹 chore: bump Dagger to 0.21.8

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,9 +8,6 @@ permissions:
   contents: read
   pull-requests: read
 
-env:
-  DAGGER_VERSION: "0.21.8"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -24,14 +21,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.4.1
-        with:
-          version: ${{ env.DAGGER_VERSION }}
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
 
       - name: Check PR title conformance
         run: |
-          dagger call -m github.com/papercomputeco/daggerverse/ghcontrib \
+          nix develop --command dagger call -m github.com/papercomputeco/daggerverse/ghcontrib@45e997aec734ec4875ff57bebed2317e1bd49185 \
               --token=env://GH_TOKEN \
               --repo="${{ github.repository }}" \
             check-pull-request \
@@ -48,14 +46,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.4.1
-        with:
-          version: ${{ env.DAGGER_VERSION }}
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
+
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
 
       - name: Check Linear magic word
         run: |
-          dagger call -m github.com/papercomputeco/daggerverse/ghcontrib \
+          nix develop --command dagger call -m github.com/papercomputeco/daggerverse/ghcontrib@45e997aec734ec4875ff57bebed2317e1bd49185 \
               --token=env://GH_TOKEN \
               --repo="${{ github.repository }}" \
             check-pull-request-linear-magic-word \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 
 env:
-  DAGGER_VERSION: "0.20.8"
+  DAGGER_VERSION: "0.21.8"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.2.0
+        uses: dagger/dagger-for-github@v8.4.1
         with:
           version: ${{ env.DAGGER_VERSION }}
 
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Dagger
-        uses: dagger/dagger-for-github@v8.2.0
+        uses: dagger/dagger-for-github@v8.4.1
         with:
           version: ${{ env.DAGGER_VERSION }}
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "dagger": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785344846,
+        "narHash": "sha256-E0v8IiF9sEWNw615Yae1RH8KtMuOOF+mcafu2m0kHyE=",
+        "owner": "dagger",
+        "repo": "nix",
+        "rev": "b35b2b5ab62ace3a3c1e779c497de1ad762a4aa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dagger",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +56,7 @@
     },
     "root": {
       "inputs": {
+        "dagger": "dagger",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,11 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    dagger.url = "github:dagger/nix";
+    dagger.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, dagger }:
     {
       overlays.default = final: prev: {
         agentd = final.buildGoModule {
@@ -85,6 +87,8 @@
 
             # Test tools
             hurl
+
+            dagger.packages.${system}.dagger
           ];
 
           shellHook = ''


### PR DESCRIPTION
Align Dagger to the tapes #273 pattern: add a `dagger` flake input (github:dagger/nix), put the CLI in the default devShell, and run PR-check workflows through `nix develop --command dagger` instead of DAGGER_VERSION + dagger-for-github.

- Pin ghcontrib to `45e997aec734ec4875ff57bebed2317e1bd49185`
- Install Nix with determinate-nix-action v3.21.8 and magic-nix-cache-action v14
- Verified `nix develop --command dagger version` → v0.21.8

Refs PCC-544